### PR TITLE
[BE] hotfix: 기본 사용자 추가

### DIFF
--- a/src/main/java/handong/whynot/WhynotApplication.java
+++ b/src/main/java/handong/whynot/WhynotApplication.java
@@ -1,15 +1,49 @@
 package handong.whynot;
 
+import handong.whynot.domain.Account;
+import handong.whynot.repository.AccountRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
+@Slf4j
 @EnableJpaAuditing
 @SpringBootApplication
 public class WhynotApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(WhynotApplication.class, args);
+    }
+
+    @Value("${test.user.name}")
+    private String username;
+
+    @Value("${test.user.password}")
+    private String password;
+
+    @Bean
+    CommandLineRunner run(AccountRepository accountRepository, PasswordEncoder passwordEncoder) {
+        return args -> {
+
+            try {
+                Account account = Account.builder()
+                        .id(2L)
+                        .nickname(username)
+                        .email(username + "@email.com")
+                        .password(passwordEncoder.encode(password))
+                        .build();
+                account.completeSignUp();
+                accountRepository.save(account);
+
+            } catch (Exception e) {
+                log.warn("이미 등록된 아이디입니다.");
+            }
+        };
     }
 
 }


### PR DESCRIPTION
postman으로 API 테스트 시에 
사용자 인증 과정을 매번 해야하는게 불편해서 기본 사용자 추가합니다.

@doljae 
username, password 정보는 whynot-config 에 있으니 참고 바랍니다~