### PR TITLE
[BE] feat: 좋아요 공고 삭제 API & 테스트

### DIFF
--- a/src/main/java/handong/whynot/api/PostController.java
+++ b/src/main/java/handong/whynot/api/PostController.java
@@ -56,4 +56,12 @@ public class PostController {
 
         return ResponseDTO.of(PostResponseCode.POST_UPDATE_OK);
     }
+
+    @DeleteMapping("/favorite/{postId}")
+    public ResponseDTO deleteFavorite(@PathVariable Long postId, @CurrentAccount Account account) {
+
+        postService.deleteFavorite(postId, account);
+
+        return ResponseDTO.of(PostResponseCode.POST_DELETE_FAVORITE_OK);
+    }
 }

--- a/src/main/java/handong/whynot/config/SecurityConfig.java
+++ b/src/main/java/handong/whynot/config/SecurityConfig.java
@@ -21,6 +21,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
                 .authorizeRequests()
                 .antMatchers("/", "/login", "/sign-up", "/check-email-token",
                         "/email-login", "/login-by-email").permitAll()
+                .antMatchers("/v1/posts/favorite/**").hasRole("USER")
                 .antMatchers(HttpMethod.GET,"/v1/posts/**").permitAll()
                 .anyRequest().authenticated()
         .and()

--- a/src/main/java/handong/whynot/dto/post/PostResponseCode.java
+++ b/src/main/java/handong/whynot/dto/post/PostResponseCode.java
@@ -18,7 +18,10 @@ public enum PostResponseCode implements ResponseCode {
     POST_UPDATE_FAIL_NOT_FOUND(40003, "공고 [수정]에 실패하였습니다. - 해당 id 찾을 수 없음"),
 
     POST_DELETE_OK(20004, "공고 [삭제]에 성공하였습니다."),
-    POST_DELETE_FAIL_NOT_FOUND(40004, "공고 [삭제]에 실패하였습니다. - 해당 id 찾을 수 없음");
+    POST_DELETE_FAIL_NOT_FOUND(40004, "공고 [삭제]에 실패하였습니다. - 해당 id 찾을 수 없음"),
+
+    POST_DELETE_FAVORITE_OK(20006, "좋아요 공고 [삭제]에 성공하였습니다."),
+    POST_DELETE_FAVORITE_FAIL(40006, "좋아요 공고 [삭제]에 실패하였습니다. - 이미 좋아요 해제되어 있습니다.");
 
     private final Integer statusCode;
     private final String message;

--- a/src/main/java/handong/whynot/exception/post/PostAlreadyFavoriteOff.java
+++ b/src/main/java/handong/whynot/exception/post/PostAlreadyFavoriteOff.java
@@ -1,0 +1,11 @@
+package handong.whynot.exception.post;
+
+import handong.whynot.dto.common.ResponseCode;
+import handong.whynot.exception.AbstractBaseException;
+
+public class PostAlreadyFavoriteOff extends AbstractBaseException {
+
+    public PostAlreadyFavoriteOff(ResponseCode responseCode) {
+        super(responseCode);
+    }
+}

--- a/src/main/java/handong/whynot/handler/PostExceptionHandler.java
+++ b/src/main/java/handong/whynot/handler/PostExceptionHandler.java
@@ -2,12 +2,14 @@ package handong.whynot.handler;
 
 import handong.whynot.dto.common.ErrorResponseDTO;
 import handong.whynot.dto.post.PostResponseCode;
+import handong.whynot.exception.post.PostAlreadyFavoriteOff;
 import handong.whynot.exception.post.PostNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @RestControllerAdvice
@@ -18,5 +20,11 @@ public class PostExceptionHandler {
     @ExceptionHandler(PostNotFoundException.class)
     public ErrorResponseDTO postNotFoundExceptionHandle() {
         return ErrorResponseDTO.of(PostResponseCode.POST_READ_FAIL, null);
+    }
+
+    @ResponseStatus(BAD_REQUEST)
+    @ExceptionHandler(PostAlreadyFavoriteOff.class)
+    public ErrorResponseDTO postAlreadyFavoriteOff() {
+        return ErrorResponseDTO.of(PostResponseCode.POST_DELETE_FAVORITE_FAIL, null);
     }
 }

--- a/src/main/java/handong/whynot/repository/PostQueryRepository.java
+++ b/src/main/java/handong/whynot/repository/PostQueryRepository.java
@@ -20,6 +20,7 @@ public class PostQueryRepository {
     private final QJob qJob = QJob.job;
     private final QPostApply qPostApply = QPostApply.postApply;
     private final QAccount qAccount = QAccount.account;
+    private final QPostFavorite qPostFavorite = QPostFavorite.postFavorite;
 
     // Post Full info
     public List<Post> getPosts() {
@@ -45,6 +46,18 @@ public class PostQueryRepository {
                                         .where(qPostApply.post.id.eq(post_id))
                         )
                 )
+                .fetch();
+    }
+
+    public List<PostFavorite> getFavoriteByPostId(Post post, Account account) {
+
+        Long postId = post.getId();
+        Long accountId = account.getId();
+
+        return queryFactory.select(qPostFavorite)
+                .from(qPost, qPostFavorite)
+                .where(qPostFavorite.account.id.eq(accountId)
+                        .and(qPostFavorite.post.id.eq(postId)))
                 .fetch();
     }
 }

--- a/src/main/java/handong/whynot/service/PostService.java
+++ b/src/main/java/handong/whynot/service/PostService.java
@@ -6,6 +6,7 @@ import handong.whynot.dto.post.PostRequestDTO;
 import handong.whynot.dto.post.PostResponseCode;
 import handong.whynot.dto.post.PostResponseDTO;
 import handong.whynot.exception.job.JobNotFoundException;
+import handong.whynot.exception.post.PostAlreadyFavoriteOff;
 import handong.whynot.exception.post.PostNotFoundException;
 import handong.whynot.repository.*;
 import lombok.RequiredArgsConstructor;
@@ -124,6 +125,20 @@ public class PostService {
         post.update(request);
 
         postRepository.save(post);
+
+    }
+
+    public void deleteFavorite(Long postId, Account account) {
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostNotFoundException(PostResponseCode.POST_READ_FAIL));
+
+        List<PostFavorite> favorite = postQueryRepository.getFavoriteByPostId(post, account);
+        if (favorite.isEmpty()) {
+            throw new PostAlreadyFavoriteOff(PostResponseCode.POST_DELETE_FAVORITE_FAIL);
+        }
+
+        postFavoriteRepository.deleteById(favorite.get(0).getId());
 
     }
 }

--- a/src/test/java/handong/whynot/api/PostServiceMvcTest.java
+++ b/src/test/java/handong/whynot/api/PostServiceMvcTest.java
@@ -19,6 +19,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -46,6 +47,7 @@ public class PostServiceMvcTest {
     @MockBean private AccountService accountService;
     @MockBean private AccountRepository accountRepository;
     @MockBean private PostQueryRepository postQueryRepository;
+    @MockBean private PasswordEncoder passwordEncoder;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;
@@ -138,6 +140,17 @@ public class PostServiceMvcTest {
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(jsonPath("statusCode").value(20003))
+                .andDo(print());
+
+    }
+
+    @DisplayName("공고 좋아요 취소 삭제")
+    @Test
+    @WithMockCustomUser
+    void deleteFavoriteTest() throws Exception {
+
+        mockMvc.perform(delete("/v1/posts/favorite/{postId}", 1L))
+                .andExpect(jsonPath("statusCode").value(20006))
                 .andDo(print());
 
     }


### PR DESCRIPTION
개발된 API 내역은 다음과 같습니다.


<table> 	
  <tr>    
    <td>Index</td> 	    
    <td>Method</td> 
    <td>Route</td> 
    <td>Description</td> 
  </tr>	
  <tr>	    
    <td>1</td> 	    
    <td>DELETE</td> 	
    <td>/v1/posts/favorite/{favorite_id}</td> 	    
    <td>‘좋아요’ 공고 삭제 생성 (좋아요 off)</td> 	    
  </tr>  
</table>