### PR TITLE
[BE] feat: 공고 신청 생성 API & 테스트

### DIFF
--- a/src/main/java/handong/whynot/api/PostController.java
+++ b/src/main/java/handong/whynot/api/PostController.java
@@ -3,6 +3,7 @@ package handong.whynot.api;
 import handong.whynot.domain.Account;
 import handong.whynot.dto.account.CurrentAccount;
 import handong.whynot.dto.common.ResponseDTO;
+import handong.whynot.dto.post.PostApplyRequestDTO;
 import handong.whynot.dto.post.PostRequestDTO;
 import handong.whynot.dto.post.PostResponseCode;
 import handong.whynot.dto.post.PostResponseDTO;
@@ -55,5 +56,14 @@ public class PostController {
         postService.updatePost(postId, request, account);
 
         return ResponseDTO.of(PostResponseCode.POST_UPDATE_OK);
+    }
+
+    @PostMapping("/apply/{postId}")
+    @ResponseStatus(CREATED)
+    public ResponseDTO createFavorite(@PathVariable Long postId, @RequestBody PostApplyRequestDTO request, @CurrentAccount Account account) {
+
+        postService.createApply(postId, request, account);
+
+        return ResponseDTO.of(PostResponseCode.POST_CREATE_APPLY_OK);
     }
 }

--- a/src/main/java/handong/whynot/api/PostController.java
+++ b/src/main/java/handong/whynot/api/PostController.java
@@ -60,7 +60,7 @@ public class PostController {
 
     @PostMapping("/apply/{postId}")
     @ResponseStatus(CREATED)
-    public ResponseDTO createFavorite(@PathVariable Long postId, @RequestBody PostApplyRequestDTO request, @CurrentAccount Account account) {
+    public ResponseDTO createApply(@PathVariable Long postId, @RequestBody PostApplyRequestDTO request, @CurrentAccount Account account) {
 
         postService.createApply(postId, request, account);
 

--- a/src/main/java/handong/whynot/config/SecurityConfig.java
+++ b/src/main/java/handong/whynot/config/SecurityConfig.java
@@ -21,6 +21,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
                 .authorizeRequests()
                 .antMatchers("/", "/login", "/sign-up", "/check-email-token",
                         "/email-login", "/login-by-email").permitAll()
+                .antMatchers("/v1/posts/favorite/**").hasRole("USER")
                 .antMatchers(HttpMethod.GET,"/v1/posts/**").permitAll()
                 .anyRequest().authenticated()
         .and()

--- a/src/main/java/handong/whynot/config/SecurityConfig.java
+++ b/src/main/java/handong/whynot/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
                 .authorizeRequests()
                 .antMatchers("/", "/login", "/sign-up", "/check-email-token",
                         "/email-login", "/login-by-email").permitAll()
-                .antMatchers("/v1/posts/favorite/**").hasRole("USER")
+                .antMatchers("/v1/posts/favorite/**", "v1/posts/apply/**").hasRole("USER")
                 .antMatchers(HttpMethod.GET,"/v1/posts/**").permitAll()
                 .anyRequest().authenticated()
         .and()

--- a/src/main/java/handong/whynot/dto/post/PostApplyRequestDTO.java
+++ b/src/main/java/handong/whynot/dto/post/PostApplyRequestDTO.java
@@ -1,0 +1,13 @@
+package handong.whynot.dto.post;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostApplyRequestDTO {
+
+    private Long job;
+}

--- a/src/main/java/handong/whynot/dto/post/PostResponseCode.java
+++ b/src/main/java/handong/whynot/dto/post/PostResponseCode.java
@@ -18,7 +18,10 @@ public enum PostResponseCode implements ResponseCode {
     POST_UPDATE_FAIL_NOT_FOUND(40003, "공고 [수정]에 실패하였습니다. - 해당 id 찾을 수 없음"),
 
     POST_DELETE_OK(20004, "공고 [삭제]에 성공하였습니다."),
-    POST_DELETE_FAIL_NOT_FOUND(40004, "공고 [삭제]에 실패하였습니다. - 해당 id 찾을 수 없음");
+    POST_DELETE_FAIL_NOT_FOUND(40004, "공고 [삭제]에 실패하였습니다. - 해당 id 찾을 수 없음"),
+
+    POST_CREATE_APPLY_OK(20009, "신청한 공고 [생성]에 성공하였습니다."),
+    POST_CREATE_APPLY_FAIL(40009, "신청한 공고 [생성]에 실패하였습니다. - 이미 신청한 공고입니다.");
 
     private final Integer statusCode;
     private final String message;

--- a/src/main/java/handong/whynot/exception/post/PostAlreadyApplyOn.java
+++ b/src/main/java/handong/whynot/exception/post/PostAlreadyApplyOn.java
@@ -1,0 +1,11 @@
+package handong.whynot.exception.post;
+
+import handong.whynot.dto.common.ResponseCode;
+import handong.whynot.exception.AbstractBaseException;
+
+public class PostAlreadyApplyOn extends AbstractBaseException {
+
+    public PostAlreadyApplyOn(ResponseCode responseCode) {
+        super(responseCode);
+    }
+}

--- a/src/main/java/handong/whynot/handler/PostExceptionHandler.java
+++ b/src/main/java/handong/whynot/handler/PostExceptionHandler.java
@@ -2,12 +2,14 @@ package handong.whynot.handler;
 
 import handong.whynot.dto.common.ErrorResponseDTO;
 import handong.whynot.dto.post.PostResponseCode;
+import handong.whynot.exception.post.PostAlreadyApplyOn;
 import handong.whynot.exception.post.PostNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @RestControllerAdvice
@@ -18,5 +20,11 @@ public class PostExceptionHandler {
     @ExceptionHandler(PostNotFoundException.class)
     public ErrorResponseDTO postNotFoundExceptionHandle() {
         return ErrorResponseDTO.of(PostResponseCode.POST_READ_FAIL, null);
+    }
+
+    @ResponseStatus(BAD_REQUEST)
+    @ExceptionHandler(PostAlreadyApplyOn.class)
+    public ErrorResponseDTO postAlreadyFavoriteOn() {
+        return ErrorResponseDTO.of(PostResponseCode.POST_CREATE_APPLY_FAIL, null);
     }
 }

--- a/src/main/java/handong/whynot/repository/PostQueryRepository.java
+++ b/src/main/java/handong/whynot/repository/PostQueryRepository.java
@@ -47,4 +47,16 @@ public class PostQueryRepository {
                 )
                 .fetch();
     }
+
+    public List<PostApply> getApplyByPostId(Post post, Account account) {
+
+        Long postId = post.getId();
+        Long accountId = account.getId();
+
+        return queryFactory.select(qPostApply)
+                .from(qPost, qPostApply)
+                .where(qPostApply.account.id.eq(accountId)
+                        .and(qPostApply.post.id.eq(postId)))
+                .fetch();
+    }
 }

--- a/src/main/java/handong/whynot/service/PostService.java
+++ b/src/main/java/handong/whynot/service/PostService.java
@@ -2,11 +2,15 @@ package handong.whynot.service;
 
 import handong.whynot.domain.*;
 import handong.whynot.dto.job.JobResponseCode;
+import handong.whynot.dto.post.PostApplyRequestDTO;
 import handong.whynot.dto.post.PostRequestDTO;
 import handong.whynot.dto.post.PostResponseCode;
 import handong.whynot.dto.post.PostResponseDTO;
 import handong.whynot.exception.job.JobNotFoundException;
+import handong.whynot.exception.post.PostAlreadyApplyOn;
 import handong.whynot.exception.post.PostNotFoundException;
+import handong.whynot.mail.EmailMessage;
+import handong.whynot.mail.EmailService;
 import handong.whynot.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,6 +30,7 @@ public class PostService {
     private final AccountRepository accountRepository;
     private final PostFavoriteRepository postFavoriteRepository;
     private final PostApplyRepository postApplyRepository;
+    private final EmailService emailService;
     
     public List<PostResponseDTO> getPosts() {
 
@@ -125,5 +130,39 @@ public class PostService {
 
         postRepository.save(post);
 
+    }
+
+    public void createApply(Long postId, PostApplyRequestDTO request, Account account) {
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostNotFoundException(PostResponseCode.POST_READ_FAIL));
+
+        Job job = jobRepository.findById(request.getJob())
+                .orElseThrow(() -> new JobNotFoundException(JobResponseCode.JOB_READ_FAIL));
+
+        if (!postQueryRepository.getApplyByPostId(post, account).isEmpty()) {
+            throw new PostAlreadyApplyOn(PostResponseCode.POST_CREATE_APPLY_FAIL);
+        }
+
+        PostApply postApply = PostApply.builder()
+                .post(post)
+                .job(job)
+                .account(account)
+                .build();
+
+        postApplyRepository.save(postApply);
+
+        // 이메일 전송
+        String message = account.getNickname() + " 님이"
+                + post.getTitle() + " 공고에 "
+                + job.getName() + " 직무로 지원 요청을 하였습니다.";
+
+        EmailMessage emailMessage = EmailMessage.builder()
+                .to(post.getCreatedBy().getEmail())
+                .subject("[공고 지원 알림] "+post.getTitle()+" by "+account.getNickname())
+                .message(message)
+                .build();
+
+        emailService.sendEmail(emailMessage);
     }
 }

--- a/src/test/java/handong/whynot/api/PostServiceMvcTest.java
+++ b/src/test/java/handong/whynot/api/PostServiceMvcTest.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import handong.whynot.common.WithMockCustomUser;
 import handong.whynot.domain.Account;
 import handong.whynot.domain.Post;
+import handong.whynot.dto.post.PostApplyRequestDTO;
 import handong.whynot.dto.post.PostRequestDTO;
 import handong.whynot.dto.post.PostResponseDTO;
+import handong.whynot.mail.EmailService;
 import handong.whynot.repository.AccountRepository;
 import handong.whynot.repository.PostQueryRepository;
 import handong.whynot.repository.PostRepository;
@@ -14,11 +16,13 @@ import handong.whynot.service.PostService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -46,6 +50,8 @@ public class PostServiceMvcTest {
     @MockBean private AccountService accountService;
     @MockBean private AccountRepository accountRepository;
     @MockBean private PostQueryRepository postQueryRepository;
+    @MockBean private PasswordEncoder passwordEncoder;
+    @MockBean private EmailService emailService;
 
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;
@@ -140,5 +146,22 @@ public class PostServiceMvcTest {
                 .andExpect(jsonPath("statusCode").value(20003))
                 .andDo(print());
 
+    }
+
+    @DisplayName("공고 신청 성공")
+    @Test
+    @WithMockCustomUser
+    void createApplyTest() throws Exception {
+
+        PostApplyRequestDTO requestDTO = PostApplyRequestDTO.builder().job(1L).build();
+
+        mockMvc.perform(post("/v1/posts/apply/{postId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDTO)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("statusCode").value(20009))
+        ;
     }
 }

--- a/src/test/java/handong/whynot/service/PostServiceTest.java
+++ b/src/test/java/handong/whynot/service/PostServiceTest.java
@@ -3,12 +3,15 @@ package handong.whynot.service;
 import handong.whynot.domain.*;
 import handong.whynot.dto.account.AccountResponseCode;
 import handong.whynot.dto.job.JobResponseCode;
+import handong.whynot.dto.post.PostApplyRequestDTO;
 import handong.whynot.dto.post.PostRequestDTO;
 import handong.whynot.dto.post.PostResponseCode;
 import handong.whynot.dto.post.PostResponseDTO;
 import handong.whynot.exception.account.AccountNotFoundException;
 import handong.whynot.exception.job.JobNotFoundException;
+import handong.whynot.exception.post.PostAlreadyApplyOn;
 import handong.whynot.exception.post.PostNotFoundException;
+import handong.whynot.mail.EmailService;
 import handong.whynot.repository.*;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -38,6 +41,7 @@ class PostServiceTest {
     @Mock private AccountRepository accountRepository;
     @Mock private PostFavoriteRepository postFavoriteRepository;
     @Mock private PostApplyRepository postApplyRepository;
+    @Mock private EmailService emailService;
 
 
     @InjectMocks
@@ -304,5 +308,80 @@ class PostServiceTest {
         // then
         verify(postApplyRepository, times(1)).findAllByPost(post);
         verify(postApplyRepository, times(postApplys.size())).deleteById(anyLong());
+    }
+
+    @DisplayName("공고 신청 [실패1] - 없는 공고인 경우")
+    @Test
+    void createApplyNotFoundPostException1() {
+
+        // given
+        Account account = Account.builder().build();
+        Long notExistId = 12345L;
+        PostApplyRequestDTO requestDTO = PostApplyRequestDTO.builder().build();
+        when(postRepository.findById(notExistId)).thenThrow(new PostNotFoundException(PostResponseCode.POST_READ_FAIL));
+
+        // when, then
+        PostNotFoundException exception =
+                assertThrows(PostNotFoundException.class, () -> postService.createApply(notExistId, requestDTO, account));
+        assertEquals(PostResponseCode.POST_READ_FAIL, exception.getResponseCode());
+
+        verify(jobRepository, never()).findById(anyLong());
+        verify(postQueryRepository, never()).getApplyByPostId(any(), any());
+        verify(postApplyRepository, never()).save(any());
+        verify(emailService, never()).sendEmail(any());
+
+    }
+
+    @DisplayName("공고 신청 [실패2] - 없는 직군인 경우")
+    @Test
+    void createApplyNotFoundPostException2() {
+
+        // given
+        Account account = Account.builder().build();
+        Long postId = 1L;
+        Post post = Post.builder().id(postId).build();
+
+        Long notExistJobId = 12345L;
+        PostApplyRequestDTO requestDTO = PostApplyRequestDTO.builder().job(notExistJobId).build();
+
+        when(postRepository.findById(anyLong())).thenReturn(Optional.ofNullable(post));
+        when(jobRepository.findById(notExistJobId)).thenThrow(new JobNotFoundException(JobResponseCode.JOB_READ_FAIL));
+
+        // when, then
+        JobNotFoundException exception =
+                assertThrows(JobNotFoundException.class, () -> postService.createApply(postId, requestDTO, account));
+        assertEquals(JobResponseCode.JOB_READ_FAIL, exception.getResponseCode());
+
+        verify(postQueryRepository, never()).getApplyByPostId(any(), any());
+        verify(postApplyRepository, never()).save(any());
+        verify(emailService, never()).sendEmail(any());
+
+    }
+
+    @DisplayName("공고 신청 [실패3] - 이미 신청한 공고인 경우")
+    @Test
+    void createApplyAlreadyOnException() {
+
+        // given
+        Account account = Account.builder().build();
+
+        Post post = Post.builder().id(1L).build();
+        PostApplyRequestDTO requestDTO = PostApplyRequestDTO.builder().job(1L).build();
+
+        PostApply postApply = PostApply.builder().build();
+
+        Job job = Job.builder().id(1L).build();
+
+        when(postRepository.findById(anyLong())).thenReturn(Optional.ofNullable(post));
+        when(jobRepository.findById(anyLong())).thenReturn(Optional.ofNullable(job));
+        when(postQueryRepository.getApplyByPostId(post, account)).thenThrow(new PostAlreadyApplyOn(PostResponseCode.POST_CREATE_APPLY_FAIL));
+
+        // when, then
+        PostAlreadyApplyOn exception =
+                assertThrows(PostAlreadyApplyOn.class, () -> postService.createApply(post.getId(), requestDTO, account));
+        assertEquals(PostResponseCode.POST_CREATE_APPLY_FAIL, exception.getResponseCode());
+
+        verify(postApplyRepository, never()).save(any());
+        verify(emailService, never()).sendEmail(any());
     }
 }


### PR DESCRIPTION
개발된 API 내역은 다음과 같습니다.

<table> 	
  <tr>    
    <td>Index</td> 	    
    <td>Method</td> 
    <td>Route</td> 
    <td>Description</td> 
  </tr>	
  <tr>	    
    <td>1</td> 	    
    <td>POST</td> 	
    <td>/v1/posts/apply/{postId}</td> 	    
    <td>공고 신청 단건 생성 (지원) + 이메일 알림</td> 	    
  </tr>  
</table>