### PR TITLE
[BE] feat: SwaggerConfig 추가 및 기타 관련 설정 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // swagger
-    implementation 'org.springdoc:springdoc-openapi-ui:1.6.5'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.6'
 
     // database
     runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/handong/whynot/api/AccountController.java
+++ b/src/main/java/handong/whynot/api/AccountController.java
@@ -23,7 +23,7 @@ public class AccountController {
 
     @PostMapping("/sign-up")
     public ResponseDTO signUp(@Valid @RequestBody SignUpDTO signUpDTO, Errors errors) {
-        // TODO: 22.02.20. seokjae.lee, MethodArgumentNotValidException 을 ExceptionHandler로 처리
+        // TODO: 22.02.20. MethodArgumentNotValidException 을 ExceptionHandler로 처리
         // 입력 검증 (사용자)
         if(errors.hasErrors()) {
             throw new AccountNotValidFormException(AccountResponseCode.ACCOUNT_NOT_VALID_FROM);

--- a/src/main/java/handong/whynot/api/JobController.java
+++ b/src/main/java/handong/whynot/api/JobController.java
@@ -19,7 +19,7 @@ public class JobController {
 
     private final JobService jobService;
 
-    // TODO: 22.02.20. seokjae.lee, DTO로 변환하는 작업을 하는 layer를 통일할 것
+    // TODO: 22.02.20. DTO로 변환하는 작업을 하는 layer를 통일할 것
     @GetMapping("")
     public List<JobResponseDTO> getJobs() {
 

--- a/src/main/java/handong/whynot/config/SecurityConfig.java
+++ b/src/main/java/handong/whynot/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
                 .antMatchers("/", "/login", "/sign-up", "/check-email-token",
                         "/email-login", "/login-by-email").permitAll()
                 .antMatchers("/v1/posts/favorite/**", "/v1/posts/apply/**", "/v1/posts/own/**").hasRole("USER")
-                .antMatchers(HttpMethod.GET,"/v1/posts/**", "/v1/comments/**").permitAll()
+                .antMatchers(HttpMethod.GET,"/v1/posts/**", "/v1/comments/**","/swagger-ui/**","/v3/api-docs/**").permitAll()
                 .anyRequest().authenticated()
         .and()
                 .formLogin()

--- a/src/main/java/handong/whynot/config/SwaggerConfig.java
+++ b/src/main/java/handong/whynot/config/SwaggerConfig.java
@@ -1,0 +1,68 @@
+package handong.whynot.config;
+
+import org.apache.commons.lang.StringUtils;
+import org.springdoc.core.GroupedOpenApi;
+import org.springdoc.core.customizers.OpenApiCustomiser;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.info.Info;
+
+@Configuration
+public class SwaggerConfig {
+    private static final String TITLE = "whynot-here-api";
+    private static final String DESCRIPTION = "whynot-here-api";
+    private static final String VERSION = "1.0.0";
+
+    public static OpenApiCustomiser globalOpenApiCustomer() {
+        return openApi ->
+            openApi.info(new Info()
+                             .title(TITLE)
+                             .description(DESCRIPTION)
+                             .version(VERSION));
+
+    }
+
+    // 22.03.13. 추후 API가 많아질 때 group 적용
+    public GroupedOpenApi accountGroup() {
+        return GroupedOpenApi.builder()
+                             .group("Account")
+                             .addOpenApiCustomiser(globalOpenApiCustomer())
+                             .addOpenApiMethodFilter(method ->
+                                                         StringUtils.contains(
+                                                             String.valueOf(method.getDeclaringClass()),
+                                                             "AccountController"))
+                             .build();
+    }
+
+    public GroupedOpenApi commentGroup() {
+        return GroupedOpenApi.builder()
+                             .group("Comment")
+                             .pathsToMatch("/*/comments/**")
+                             .addOpenApiCustomiser(globalOpenApiCustomer())
+                             .build();
+    }
+
+    public GroupedOpenApi jobGroup() {
+        return GroupedOpenApi.builder()
+                             .group("Job")
+                             .pathsToMatch("/*/jobs/**")
+                             .addOpenApiCustomiser(globalOpenApiCustomer())
+                             .build();
+    }
+
+    public GroupedOpenApi postGroup() {
+        return GroupedOpenApi.builder()
+                             .group("Post")
+                             .pathsToMatch("/*/posts/**")
+                             .addOpenApiCustomiser(globalOpenApiCustomer())
+                             .build();
+    }
+
+    public GroupedOpenApi s3Group() {
+        return GroupedOpenApi.builder()
+                             .group("S3")
+                             .pathsToMatch("/image/**")
+                             .addOpenApiCustomiser(globalOpenApiCustomer())
+                             .build();
+    }
+}

--- a/src/main/java/handong/whynot/exception/post/PostAlreadyApplyOff.java
+++ b/src/main/java/handong/whynot/exception/post/PostAlreadyApplyOff.java
@@ -3,7 +3,7 @@ package handong.whynot.exception.post;
 import handong.whynot.dto.common.ResponseCode;
 import handong.whynot.exception.AbstractBaseException;
 
-// TODO: 22.02.20. seokjae.lee, Exception 클래스 네이밍 통일
+// TODO: 22.02.20. Exception 클래스 네이밍 통일
 public class PostAlreadyApplyOff extends AbstractBaseException {
 
     public PostAlreadyApplyOff(ResponseCode responseCode) {

--- a/src/main/java/handong/whynot/util/ImageType.java
+++ b/src/main/java/handong/whynot/util/ImageType.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-// TODO: 22.02.20. seokjae.lee, 패키지 위치 재고려
+// TODO: 22.02.20. 패키지 위치 재고려
 public final class ImageType {
 
     public static final List<String> IMAGE_MIME_TYPES = new ArrayList<>(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,3 +50,13 @@ cloud:
       static: ${aws.s3.staticName}
     stack:
       auto: false
+
+springdoc:
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    filter: true
+    operationsSorter: method
+    tagsSorter: alpha
+    defaultModelsExpandDepth: 0
+    docExpansion: none


### PR DESCRIPTION
## Description
- springdoc-openapi 버전 업데이트, `1.6.5 -> 1.6.6`
- SwaggerConfig 추가
- swagger 관련 URI 접근 permitAll()

## Additional Informaiton
- `application.yml`을 `DEV`, `PROD`로 나누어 `PROD`에선 swagger를 비활성화시키는 작업이 추가적으로 있으면 좋을 것 같습니다.
- url의 네이밍 통일 및 코드 정리에 관해 의견을 나눠보면 좋을 것 같습니다.