### PR TITLE
[BE] 회원가입 form 검증 후 에러 반환 로직 리팩터링

### DIFF
--- a/src/main/java/handong/whynot/api/AccountController.java
+++ b/src/main/java/handong/whynot/api/AccountController.java
@@ -1,19 +1,18 @@
 package handong.whynot.api;
 
-import handong.whynot.domain.Account;
-import handong.whynot.dto.account.AccountResponseCode;
-import handong.whynot.dto.account.SignUpDTO;
-import handong.whynot.dto.common.ResponseDTO;
-import handong.whynot.exception.account.AccountNotValidFormException;
-import handong.whynot.service.AccountService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.validation.Errors;
+import javax.validation.Valid;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.validation.Valid;
+import handong.whynot.domain.Account;
+import handong.whynot.dto.account.AccountResponseCode;
+import handong.whynot.dto.account.SignUpDTO;
+import handong.whynot.dto.common.ResponseDTO;
+import handong.whynot.service.AccountService;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,13 +21,7 @@ public class AccountController {
     private final AccountService accountService;
 
     @PostMapping("/sign-up")
-    public ResponseDTO signUp(@Valid @RequestBody SignUpDTO signUpDTO, Errors errors) {
-        // TODO: 22.02.20. seokjae.lee, MethodArgumentNotValidException 을 ExceptionHandler로 처리
-        // 입력 검증 (사용자)
-        if(errors.hasErrors()) {
-            throw new AccountNotValidFormException(AccountResponseCode.ACCOUNT_NOT_VALID_FROM);
-        }
-
+    public ResponseDTO signUp(@Valid @RequestBody SignUpDTO signUpDTO) {
         // Account 저장
         Account account = accountService.createAccount(signUpDTO);
 

--- a/src/main/java/handong/whynot/handler/MethodArgumentNotValidExceptionHandler.java
+++ b/src/main/java/handong/whynot/handler/MethodArgumentNotValidExceptionHandler.java
@@ -1,0 +1,22 @@
+package handong.whynot.handler;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import handong.whynot.dto.account.AccountResponseCode;
+import handong.whynot.dto.common.ErrorResponseDTO;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class MethodArgumentNotValidExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorResponseDTO postNotFoundExceptionHandle() {
+        return ErrorResponseDTO.of(AccountResponseCode.ACCOUNT_NOT_VALID_FROM, null);
+    }
+}

--- a/src/test/java/handong/whynot/api/AccountControllerTest.java
+++ b/src/test/java/handong/whynot/api/AccountControllerTest.java
@@ -1,0 +1,128 @@
+package handong.whynot.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import handong.whynot.config.AppConfig;
+import handong.whynot.config.SecurityConfig;
+import handong.whynot.dto.account.AccountResponseCode;
+import handong.whynot.dto.account.SignUpDTO;
+import handong.whynot.repository.AccountRepository;
+import handong.whynot.service.AccountService;
+
+@WebMvcTest(AccountController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@Import({ SecurityConfig.class, AppConfig.class })
+class AccountControllerTest {
+
+    @MockBean
+    private AccountService accountService;
+    @MockBean
+    private AccountRepository accountRepository;
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static final String SIGN_UP_URL = "/sign-up";
+
+    @Test
+    void signUpWithValidInput() throws Exception {
+        final SignUpDTO signUpDTOWithShortNickName = new SignUpDTO("test",
+                                                                   "test@test.com",
+                                                                   "12345678");
+
+        mockMvc.perform(post(SIGN_UP_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(signUpDTOWithShortNickName)))
+               .andDo(print())
+               .andExpect(status().isOk())
+               .andExpect(
+                   jsonPath("statusCode").value(AccountResponseCode.ACCOUNT_CREATE_TOKEN_OK.getStatusCode()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("INVALID_NICKNAMES")
+    @NullAndEmptySource
+    void signUpWithInvalidNickname(String nickname) throws Exception {
+        final SignUpDTO signUpDTOWithTooShortNickName = new SignUpDTO(nickname,
+                                                                      "test@test.com",
+                                                                      "12345678");
+
+        mockMvc.perform(post(SIGN_UP_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(signUpDTOWithTooShortNickName)))
+               .andDo(print())
+               .andExpect(status().is5xxServerError())
+               .andExpect(
+                   jsonPath("statusCode").value(AccountResponseCode.ACCOUNT_NOT_VALID_FROM.getStatusCode()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("INVALID_EMAILS")
+    @NullAndEmptySource
+    void signUpWithInvalidEmail(String email) throws Exception {
+        final SignUpDTO signUpDTOWithInvalidEmail = new SignUpDTO("test",
+                                                                  email,
+                                                                  "12345678");
+
+        mockMvc.perform(post(SIGN_UP_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(signUpDTOWithInvalidEmail)))
+               .andDo(print())
+               .andExpect(status().is5xxServerError())
+               .andExpect(
+                   jsonPath("statusCode").value(AccountResponseCode.ACCOUNT_NOT_VALID_FROM.getStatusCode()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("INVALID_PASSWORDS")
+    @NullAndEmptySource
+    void signUpWithInvalidPassword(String password) throws Exception {
+        final SignUpDTO signUpDTOWithInvalidPassword = new SignUpDTO("test",
+                                                                     "test@test.com",
+                                                                     password);
+
+        mockMvc.perform(post(SIGN_UP_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(signUpDTOWithInvalidPassword)))
+               .andDo(print())
+               .andExpect(status().is5xxServerError())
+               .andExpect(
+                   jsonPath("statusCode").value(AccountResponseCode.ACCOUNT_NOT_VALID_FROM.getStatusCode()));
+    }
+
+    private static List<String> INVALID_NICKNAMES() {
+        return List.of("s".repeat(2), "s".repeat(21));
+    }
+
+    private static List<String> INVALID_EMAILS() {
+        return List.of("invalid-email-pattern", "19dk2390d0e9d");
+    }
+
+    private static List<String> INVALID_PASSWORDS() {
+        return List.of("1".repeat(7), "1".repeat(51));
+    }
+}


### PR DESCRIPTION
## Description
- `MethodArgumentNotValidExceptionHandler` 추가
  - `@Valid`로 검증 후 에러가 발생하면 `MethodArgumentNotValidException`이 발생함
  - `MethodArgumentNotValidException`을 `ExceptionHandler`로 처리
- `AccountControllerTest` 추가

## Additional Informaiton
- None