### PR TITLE
[BE] feat: auth 로직 변경 및 중복체크 API추가

### DIFF
--- a/src/main/java/handong/whynot/api/AccountController.java
+++ b/src/main/java/handong/whynot/api/AccountController.java
@@ -2,21 +2,17 @@ package handong.whynot.api;
 
 import javax.validation.Valid;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import handong.whynot.dto.account.*;
+import org.springframework.web.bind.annotation.*;
 
 import handong.whynot.domain.Account;
-import handong.whynot.dto.account.AccountResponseCode;
-import handong.whynot.dto.account.ResendTokenDTO;
-import handong.whynot.dto.account.SignUpDTO;
 import handong.whynot.dto.common.ResponseDTO;
 import handong.whynot.service.AccountService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/v1")
 public class AccountController {
 
     private final AccountService accountService;
@@ -27,7 +23,7 @@ public class AccountController {
         // Account 저장
         Account account = accountService.createAccount(signUpDTO);
 
-        return ResponseDTO.of(AccountResponseCode.ACCOUNT_CREATE_TOKEN_OK);
+        return ResponseDTO.of(AccountResponseCode.ACCOUNT_CREATE_OK);
     }
 
     @GetMapping("/check-email-token")
@@ -38,11 +34,19 @@ public class AccountController {
         return ResponseDTO.of(AccountResponseCode.ACCOUNT_VERIFY_OK);
     }
 
-    @PostMapping("/resend-token")
-    public ResponseDTO resendToken(@RequestBody ResendTokenDTO dto) {
+    @PostMapping("/check-email-duplicate")
+    public ResponseDTO checkEmailDuplicate(@RequestBody EmailDTO dto) {
 
-        accountService.resendToken(dto.getEmail());
+        accountService.checkEmailDuplicateAndGenerateAccountAndSendEmail(dto.getEmail());
 
         return ResponseDTO.of(AccountResponseCode.ACCOUNT_CREATE_TOKEN_OK);
+    }
+
+    @PostMapping("/check-nickname-duplicate")
+    public ResponseDTO checkNicknameDuplicate(@RequestBody NicknameDTO dto) {
+
+        accountService.checkNicknameDuplicate(dto.getNickname());
+
+        return ResponseDTO.of(AccountResponseCode.ACCOUNT_VALID_DUPLICATE);
     }
 }

--- a/src/main/java/handong/whynot/config/SecurityConfig.java
+++ b/src/main/java/handong/whynot/config/SecurityConfig.java
@@ -23,8 +23,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
         http
                 .csrf().disable()   // 개발 단계에서만 허용
                 .authorizeRequests()
-                .antMatchers("/", "/login", "/sign-up", "/check-email-token", "/resend-token",
-                        "/email-login", "/login-by-email").permitAll()
+                .antMatchers("/", "/v1/login", "/v1/sign-up", "/v1/check-email-token", "/v1/resend-token",
+                        "/v1/check-email-duplicate", "/v1/check-nickname-duplicate").permitAll()
                 .antMatchers("/v1/posts/favorite/**", "/v1/posts/apply/**", "/v1/posts/own/**").hasRole("USER")
                 .antMatchers(HttpMethod.GET,"/v1/posts/**", "/v1/comments/**","/swagger-ui/**","/v3/api-docs/**").permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/handong/whynot/dto/account/AccountResponseCode.java
+++ b/src/main/java/handong/whynot/dto/account/AccountResponseCode.java
@@ -25,7 +25,9 @@ public enum AccountResponseCode implements ResponseCode {
     ACCOUNT_NOT_VALID_TOKEN(40008, "사용자 [이메일 토큰검증]에 실패하였습니다."),
     ACCOUNT_CREATE_TOKEN_OK(20005, "사용자 [토큰생성]에 성공하였습니다."),
     ACCOUNT_VERIFY_OK(20006, "사용자 [이메일 토큰검증]에 성공하였습니다."),
-    ACCOUNT_FORBIDDEN(40009, "사용자 인증이 필요합니다.");
+    ACCOUNT_FORBIDDEN(40009, "사용자 인증이 필요합니다."),
+
+    ACCOUNT_VALID_DUPLICATE(20007, "사용 가능한 인자입니다.");
 
     private final Integer statusCode;
     private final String message;

--- a/src/main/java/handong/whynot/dto/account/EmailDTO.java
+++ b/src/main/java/handong/whynot/dto/account/EmailDTO.java
@@ -1,0 +1,9 @@
+package handong.whynot.dto.account;
+
+import lombok.Getter;
+
+@Getter
+public class EmailDTO {
+
+    private String email;
+}

--- a/src/main/java/handong/whynot/dto/account/NicknameDTO.java
+++ b/src/main/java/handong/whynot/dto/account/NicknameDTO.java
@@ -1,0 +1,9 @@
+package handong.whynot.dto.account;
+
+import lombok.Getter;
+
+@Getter
+public class NicknameDTO {
+
+    private String nickname;
+}

--- a/src/main/java/handong/whynot/dto/post/PostResponseDTO.java
+++ b/src/main/java/handong/whynot/dto/post/PostResponseDTO.java
@@ -34,7 +34,7 @@ public class PostResponseDTO {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_PATTERN, timezone = "Asia/Seoul")
     private LocalDateTime updatedDt;
 
-    private AccountResponseDTO owner;
+    private AccountResponseDTO writer;
 
     private String content;
 
@@ -53,7 +53,7 @@ public class PostResponseDTO {
                 .postImg(post.getPostImg())
                 .createdDt(post.getCreatedDt())
                 .updatedDt(post.getUpdatedDt())
-                .owner(post.getCreatedBy().getAccountDTO())
+                .writer(post.getCreatedBy().getAccountDTO())
                 .content(post.getContent())
                 .isRecruiting(post.isRecruiting())
                 .jobs(jobs)

--- a/src/main/java/handong/whynot/handler/AccountExceptionHandler.java
+++ b/src/main/java/handong/whynot/handler/AccountExceptionHandler.java
@@ -2,12 +2,13 @@ package handong.whynot.handler;
 
 import handong.whynot.dto.common.ErrorResponseDTO;
 import handong.whynot.dto.account.AccountResponseCode;
-import handong.whynot.exception.account.AccountNotFoundException;
+import handong.whynot.exception.account.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @RestControllerAdvice
@@ -18,5 +19,29 @@ public class AccountExceptionHandler {
     @ExceptionHandler(AccountNotFoundException.class)
     public ErrorResponseDTO postNotFoundExceptionHandle() {
         return ErrorResponseDTO.of(AccountResponseCode.ACCOUNT_READ_FAIL, null);
+    }
+
+    @ResponseStatus(BAD_REQUEST)
+    @ExceptionHandler(AccountAlreadyExistEmailException.class)
+    public ErrorResponseDTO emailAlreadyExistExceptionHandle() {
+        return ErrorResponseDTO.of(AccountResponseCode.ACCOUNT_ALREADY_EXIST_EMAIL, null);
+    }
+
+    @ResponseStatus(BAD_REQUEST)
+    @ExceptionHandler(AccountAlreadyExistNicknameException.class)
+    public ErrorResponseDTO nicknameAlreadyExistExceptionHandle() {
+        return ErrorResponseDTO.of(AccountResponseCode.ACCOUNT_ALREADY_EXIST_NICKNAME, null);
+    }
+
+    @ResponseStatus(BAD_REQUEST)
+    @ExceptionHandler(AccountNotValidFormException.class)
+    public ErrorResponseDTO notValidFormExceptionHandle() {
+        return ErrorResponseDTO.of(AccountResponseCode.ACCOUNT_NOT_VALID_FROM, null);
+    }
+
+    @ResponseStatus(BAD_REQUEST)
+    @ExceptionHandler(AccountNotValidToken.class)
+    public ErrorResponseDTO notValidTokenExceptionHandle() {
+        return ErrorResponseDTO.of(AccountResponseCode.ACCOUNT_NOT_VALID_TOKEN, null);
     }
 }

--- a/src/main/java/handong/whynot/repository/AccountQueryRepository.java
+++ b/src/main/java/handong/whynot/repository/AccountQueryRepository.java
@@ -1,0 +1,30 @@
+package handong.whynot.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import handong.whynot.domain.Account;
+import handong.whynot.domain.QAccount;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AccountQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private final QAccount qAccount = QAccount.account;
+
+    public Account findByVerifiedEmail(String email) {
+        return queryFactory.selectFrom(qAccount)
+                .where(qAccount.email.eq(email)
+                        .and(qAccount.emailVerified.isTrue()))
+                .fetchOne();
+    }
+
+    public Account findByVerifiedNickname(String nickname) {
+        return queryFactory.selectFrom(qAccount)
+                .where(qAccount.nickname.eq(nickname)
+                        .and(qAccount.emailVerified.isTrue()))
+                .fetchOne();
+    }
+}


### PR DESCRIPTION
프론트 팀에서 요구한대로 이메일 인증 로직이 많이 변경되었습니다.
변경된 후의 로직을 아래에 설명 드리겠습니다.

1. `/v1/check-email-duplicate` 를 통해 이메일 중복 체크를 합니다.
  - email 인증이 완료된 email이 존재한다면, 중복으로 처리합니다.
  - email 인증이 완료되지 않은 email이라면, 해당 URL 호출로 email 토큰 전송을 하게 됩니다. (여러번 가능) => 추후 시간 제한 필요

2. `/v1/check-nickname-duplicate` 를 통해 닉네임 중복 체크를 합니다.

3. `v1/check-email-token?token&email` 를 통해 토큰 검증을 합니다.

4. `/v1/sign-up` 를 통해 nickname, email, password를 받아서 Account 정보를 업데이트 합니다.

5. `/login` 를 통해 email 혹은 nickname 을 ID로, password를 PW로 로그인합니다.


다만, 현재 `AccountService.java` 의 `checkEmailDuplicateAndGenerateAccountAndSendEmail` 메서드는 리팩토링이 필요합니다.

