### PR TITLE
[BE] 로그인 endpoint를 swagger에 노출

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.6'
+    implementation 'org.springdoc:springdoc-openapi-security:1.6.6'
 
     // database
     runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,6 +54,7 @@ cloud:
 springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
+  show-login-endpoint: true
   swagger-ui:
     filter: true
     operationsSorter: method


### PR DESCRIPTION
## Description
- 로그인 endpoint를 swagger에 노출

## Additional Informaiton
- 기본적으로 swagger는 프로젝트의 @RestController를 스캔해서 swagger-ui를 그리는 것 같습니다.
- 그로 인해 Spring Security로 인해 자동 생성되는 로그인 관련 API를 노출하려면 추가 의존성과 설정이 필요합니다.
- 다만 swagger-ui에 로그인 API를 노출시켜서 얻으려는 **편의성**을 대체할 수 있는 다른 방법이 있는지 고민해보면 좋을 것 같습니다.