### PR TITLE
[BE] feat: 로그인/로그아웃 스펙 변경

### DIFF
--- a/src/main/java/handong/whynot/api/AccountController.java
+++ b/src/main/java/handong/whynot/api/AccountController.java
@@ -26,10 +26,10 @@ public class AccountController {
         return ResponseDTO.of(AccountResponseCode.ACCOUNT_CREATE_OK);
     }
 
-    @GetMapping("/check-email-token")
-    public ResponseDTO checkEmailToken(String token, String email) {
+    @PostMapping("/check-email-token")
+    public ResponseDTO checkEmailToken(@RequestBody TokenCheckDTO tokenCheckDTO) {
 
-        accountService.checkEmail(token, email);
+        accountService.checkEmail(tokenCheckDTO.getToken(), tokenCheckDTO.getEmail());
 
         return ResponseDTO.of(AccountResponseCode.ACCOUNT_VERIFY_OK);
     }
@@ -48,5 +48,15 @@ public class AccountController {
         accountService.checkNicknameDuplicate(dto.getNickname());
 
         return ResponseDTO.of(AccountResponseCode.ACCOUNT_VALID_DUPLICATE);
+    }
+
+    @GetMapping("/account/info")
+    public AccountResponseDTO getAccountInfo(@CurrentAccount Account account) {
+        return AccountResponseDTO.builder()
+                .id(account.getId())
+                .email(account.getEmail())
+                .nickname(account.getNickname())
+                .profileImg(account.getProfileImg())
+                .build();
     }
 }

--- a/src/main/java/handong/whynot/config/SecurityConfig.java
+++ b/src/main/java/handong/whynot/config/SecurityConfig.java
@@ -1,5 +1,9 @@
 package handong.whynot.config;
 
+import handong.whynot.handler.CustomAuthenticationEntryPoint;
+import handong.whynot.handler.CustomLogoutSuccessHandler;
+import handong.whynot.handler.LoginFailureHandler;
+import handong.whynot.handler.LoginSuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -18,6 +22,11 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig extends WebSecurityConfigurerAdapter{
 
+    private final LoginSuccessHandler loginSuccessHandler;
+    private final LoginFailureHandler loginFailureHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomLogoutSuccessHandler customLogoutSuccessHandler;
+
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
@@ -30,17 +39,19 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
                 .antMatchers("/v1/posts/favorite/**", "/v1/posts/apply/**", "/v1/posts/own/**").hasRole("USER")
                 .antMatchers(HttpMethod.GET,"/v1/posts/**", "/v1/comments/**","/swagger-ui/**","/v3/api-docs/**").permitAll()
                 .anyRequest().authenticated()
+                .and().exceptionHandling().authenticationEntryPoint(customAuthenticationEntryPoint)
         .and()
                 .formLogin()
-//                .loginPage()  // 프론트 URL 지정 필요
+                .loginProcessingUrl("/v1/login")
                 .usernameParameter("email")
                 .passwordParameter("password")
-                .defaultSuccessUrl("/v1/posts")
+                .successHandler(loginSuccessHandler)
+                .failureHandler(loginFailureHandler)
                 .permitAll()
         .and()
                 .logout()
-//                .logoutUrl() // 프론트 URL 지정 필요
-                .logoutSuccessUrl("/v1/posts")
+                .logoutUrl("/v1/logout")
+                .logoutSuccessHandler(customLogoutSuccessHandler)
         ;
     }
 

--- a/src/main/java/handong/whynot/dto/account/AccountResponseCode.java
+++ b/src/main/java/handong/whynot/dto/account/AccountResponseCode.java
@@ -26,8 +26,10 @@ public enum AccountResponseCode implements ResponseCode {
     ACCOUNT_CREATE_TOKEN_OK(20005, "사용자 [토큰생성]에 성공하였습니다."),
     ACCOUNT_VERIFY_OK(20006, "사용자 [이메일 토큰검증]에 성공하였습니다."),
     ACCOUNT_FORBIDDEN(40009, "사용자 인증이 필요합니다."),
+    ACCOUNT_NOT_VALID(40010, "사용자 아이디 혹은 비밀번호가 일치하지 않습니다."),
 
-    ACCOUNT_VALID_DUPLICATE(20007, "사용 가능한 인자입니다.");
+    ACCOUNT_VALID_DUPLICATE(20007, "사용 가능한 인자입니다."),
+    ACCOUNT_LOGOUT_SUCCESS(20008, "로그아웃 성공하였습니다.");
 
     private final Integer statusCode;
     private final String message;

--- a/src/main/java/handong/whynot/dto/account/TokenCheckDTO.java
+++ b/src/main/java/handong/whynot/dto/account/TokenCheckDTO.java
@@ -1,0 +1,10 @@
+package handong.whynot.dto.account;
+
+import lombok.Getter;
+
+@Getter
+public class TokenCheckDTO {
+
+    private String email;
+    private String token;
+}

--- a/src/main/java/handong/whynot/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/handong/whynot/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,45 @@
+package handong.whynot.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import handong.whynot.dto.account.AccountResponseCode;
+import handong.whynot.dto.common.ErrorResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.apache.commons.compress.utils.CharsetNames.UTF_8;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException exception) throws IOException, ServletException {
+
+        ErrorResponseDTO responseMessage = ErrorResponseDTO.of(AccountResponseCode.ACCOUNT_FORBIDDEN, null);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8);
+
+        try{
+            response.getWriter().write(objectMapper.writeValueAsString(responseMessage));
+            response.setStatus(BAD_REQUEST.value());
+        } catch (IOException e) {
+            log.error("[ExceptionHandlerFilter] Json 생성에 실패하였습니다. {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/handong/whynot/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/handong/whynot/handler/CustomAuthenticationEntryPoint.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 
 import static org.apache.commons.compress.utils.CharsetNames.UTF_8;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Slf4j
 @Component
@@ -35,10 +36,12 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(UTF_8);
 
+        response.setStatus(BAD_REQUEST.value());
+
         try{
             response.getWriter().write(objectMapper.writeValueAsString(responseMessage));
-            response.setStatus(BAD_REQUEST.value());
         } catch (IOException e) {
+            response.setStatus(INTERNAL_SERVER_ERROR.value());
             log.error("[ExceptionHandlerFilter] Json 생성에 실패하였습니다. {}", e.getMessage());
         }
     }

--- a/src/main/java/handong/whynot/handler/CustomLogoutSuccessHandler.java
+++ b/src/main/java/handong/whynot/handler/CustomLogoutSuccessHandler.java
@@ -20,8 +20,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 import static org.apache.commons.compress.utils.CharsetNames.UTF_8;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.*;
 
 @Slf4j
 @Component
@@ -39,10 +38,12 @@ public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(UTF_8);
 
+        response.setStatus(OK.value());
+
         try{
             response.getWriter().write(objectMapper.writeValueAsString(responseMessage));
-            response.setStatus(OK.value());
         } catch (IOException e) {
+            response.setStatus(INTERNAL_SERVER_ERROR.value());
             log.error("[ExceptionHandlerFilter] Json 생성에 실패하였습니다. {}", e.getMessage());
         }
     }

--- a/src/main/java/handong/whynot/handler/CustomLogoutSuccessHandler.java
+++ b/src/main/java/handong/whynot/handler/CustomLogoutSuccessHandler.java
@@ -1,0 +1,49 @@
+package handong.whynot.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import handong.whynot.dto.account.AccountResponseCode;
+import handong.whynot.dto.account.AccountResponseDTO;
+import handong.whynot.dto.account.UserAccount;
+import handong.whynot.dto.common.ErrorResponseDTO;
+import handong.whynot.dto.common.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static org.apache.commons.compress.utils.CharsetNames.UTF_8;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.OK;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
+                                Authentication authentication) throws IOException, ServletException {
+
+        ResponseDTO responseMessage = ResponseDTO.of(AccountResponseCode.ACCOUNT_LOGOUT_SUCCESS);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8);
+
+        try{
+            response.getWriter().write(objectMapper.writeValueAsString(responseMessage));
+            response.setStatus(OK.value());
+        } catch (IOException e) {
+            log.error("[ExceptionHandlerFilter] Json 생성에 실패하였습니다. {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/handong/whynot/handler/LoginFailureHandler.java
+++ b/src/main/java/handong/whynot/handler/LoginFailureHandler.java
@@ -1,0 +1,42 @@
+package handong.whynot.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import handong.whynot.dto.account.AccountResponseCode;
+import handong.whynot.dto.common.ErrorResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import static org.apache.commons.compress.utils.CharsetNames.UTF_8;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LoginFailureHandler implements AuthenticationFailureHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
+        ErrorResponseDTO responseMessage = ErrorResponseDTO.of(AccountResponseCode.ACCOUNT_NOT_VALID, null);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8);
+
+        try{
+            response.getWriter().write(objectMapper.writeValueAsString(responseMessage));
+            response.setStatus(BAD_REQUEST.value());
+        } catch (IOException e) {
+            log.error("[ExceptionHandlerFilter] Json 생성에 실패하였습니다. {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/handong/whynot/handler/LoginFailureHandler.java
+++ b/src/main/java/handong/whynot/handler/LoginFailureHandler.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 
 import static org.apache.commons.compress.utils.CharsetNames.UTF_8;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Slf4j
 @Component
@@ -32,10 +33,12 @@ public class LoginFailureHandler implements AuthenticationFailureHandler {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(UTF_8);
 
+        response.setStatus(BAD_REQUEST.value());
+
         try{
             response.getWriter().write(objectMapper.writeValueAsString(responseMessage));
-            response.setStatus(BAD_REQUEST.value());
         } catch (IOException e) {
+            response.setStatus(INTERNAL_SERVER_ERROR.value());
             log.error("[ExceptionHandlerFilter] Json 생성에 실패하였습니다. {}", e.getMessage());
         }
     }

--- a/src/main/java/handong/whynot/handler/LoginSuccessHandler.java
+++ b/src/main/java/handong/whynot/handler/LoginSuccessHandler.java
@@ -13,6 +13,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -36,6 +38,7 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
             writer.println(objectMapper.writeValueAsString(dto));
             writer.flush();
         } catch (Exception e) {
+            response.setStatus(INTERNAL_SERVER_ERROR.value());
             log.error("Json 응답에 실패했습니다.");
         }
     }

--- a/src/main/java/handong/whynot/handler/LoginSuccessHandler.java
+++ b/src/main/java/handong/whynot/handler/LoginSuccessHandler.java
@@ -1,0 +1,42 @@
+package handong.whynot.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import handong.whynot.dto.account.AccountResponseDTO;
+import handong.whynot.dto.account.UserAccount;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) {
+
+        AccountResponseDTO dto = ((UserAccount)authentication.getPrincipal()).getAccount().getAccountDTO();
+        writeTokenResponse(response, dto);
+    }
+
+    private void writeTokenResponse(HttpServletResponse response, AccountResponseDTO dto) {
+
+        try {
+            PrintWriter writer = response.getWriter();
+            writer.println(objectMapper.writeValueAsString(dto));
+            writer.flush();
+        } catch (Exception e) {
+            log.error("Json 응답에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,7 +5,6 @@ server:
   servlet:
     session:
       cookie:
-        secure: true
         same-site: NONE
         http-only: true
 


### PR DESCRIPTION
로그인 API 스펙이 다음과 같이 변경되었습니다.

< 기존 >
1. 로그인 URL : `/login`, 로그아웃 URL : `/logout`
2. 로그인, 로그아웃 후에 홈화면에 뿌려지는 posts 데이터 반환 (302 응답)
3. 로그인 실패 시 로그인 화면으로 redirect

< 변경 >
1. 로그인 URL : `/v1/login`, 로그아웃 URL : `/v1/logout`
2. 로그인, 로그아웃 후에 지정된 Response code, message 반환 (200 응답)
3. 지정된 ErrorResponse code, message 반환 (400 응답)

<br />
<br />

내용이 많아서 리뷰에 도움되실 수 있도록 postman 결과 첨부드립니다.

<hr>

1. [POST] 로그인 (/v1/login)
<img width="670" alt="image" src="https://user-images.githubusercontent.com/42775225/164006198-e683a503-caf8-49a4-8de1-23b1e53307d3.png">

<hr>

2. [POST] 로그아웃 (/v1/logout)
<img width="662" alt="image" src="https://user-images.githubusercontent.com/42775225/164006994-6d005e42-1a9a-480d-b34e-91d4fc3dbcf4.png">

<hr>

3. [POST] 로그인 실패
<img width="679" alt="image" src="https://user-images.githubusercontent.com/42775225/164007177-cc798f96-b77c-4284-b9f8-43fb9f4da412.png">

<hr>

4. 로그인 전에 인증이 필요한 리소스에 접근
<img width="610" alt="image" src="https://user-images.githubusercontent.com/42775225/164007335-aacd9df2-8ada-4731-874a-bde74dc33ba6.png">

<hr>

5. 사용자 정보를 획득하는 API도 개발되었습니다.

<table> 	
  <tr>    
    <td>Index</td> 	    
    <td>Method</td> 
    <td>Route</td> 
    <td>Description</td> 
  </tr>	
  <tr>	    
    <td>1</td> 	    
    <td>POST</td> 	
    <td>/v1/account/info</td> 	    
    <td>사용자 정보 조회</td> 	    
  </tr>  
</table>
<img width="682" alt="image" src="https://user-images.githubusercontent.com/42775225/164017163-e4dbc6f6-91df-4fd2-8966-9ef9c8df7bfa.png">

<hr>

6. 토큰 검증 API가 GET -> POST 로 변경되었습니다.
<img width="686" alt="image" src="https://user-images.githubusercontent.com/42775225/164017455-0a9f9830-b601-42ea-a344-ab2411340d74.png">

<hr>
