### PR TITLE
[BE] feat: 댓글 추가, 삭제, 조회 API

### DIFF
--- a/src/main/java/handong/whynot/api/CommentController.java
+++ b/src/main/java/handong/whynot/api/CommentController.java
@@ -1,14 +1,16 @@
 package handong.whynot.api;
 
+import handong.whynot.domain.Account;
 import handong.whynot.domain.Comment;
+import handong.whynot.dto.account.CurrentAccount;
+import handong.whynot.dto.comment.CommentRequestDTO;
+import handong.whynot.dto.comment.CommentResponseCode;
 import handong.whynot.dto.comment.CommentResponseDTO;
+import handong.whynot.dto.common.ResponseDTO;
 import handong.whynot.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -24,5 +26,22 @@ public class CommentController {
     public List<CommentResponseDTO> getCommentsByPostId(@PathVariable Long postId) {
 
         return commentService.getCommentsByPostId(postId);
+    }
+
+    @PostMapping("")
+    public ResponseDTO createComment(@RequestBody CommentRequestDTO requestDTO, @CurrentAccount Account account) {
+
+        commentService.createComment(requestDTO, account);
+
+        return ResponseDTO.of(CommentResponseCode.COMMENT_CREATE_OK);
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseDTO deleteComment(@PathVariable Long commentId, @CurrentAccount Account account) {
+
+        commentService.deleteComment(commentId, account);
+
+        return ResponseDTO.of(CommentResponseCode.COMMENT_DELETE_OK);
+
     }
 }

--- a/src/main/java/handong/whynot/domain/Comment.java
+++ b/src/main/java/handong/whynot/domain/Comment.java
@@ -24,10 +24,6 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @ManyToOne
-    @JoinColumn(name = "parent_id")
-    private Comment parent;
-
     @Column(name = "content", nullable = false)
     private String content;
 

--- a/src/main/java/handong/whynot/dto/account/AccountResponseDTO.java
+++ b/src/main/java/handong/whynot/dto/account/AccountResponseDTO.java
@@ -1,5 +1,6 @@
 package handong.whynot.dto.account;
 
+import handong.whynot.domain.Account;
 import lombok.*;
 
 @Getter
@@ -13,4 +14,13 @@ public class AccountResponseDTO {
     private String email;
     private String nickname;
     private String profileImg;
+
+    public static AccountResponseDTO of(Account account) {
+        return AccountResponseDTO.builder()
+                .id(account.getId())
+                .email(account.getEmail())
+                .nickname(account.getNickname())
+                .profileImg(account.getProfileImg())
+                .build();
+    }
 }

--- a/src/main/java/handong/whynot/dto/comment/CommentRequestDTO.java
+++ b/src/main/java/handong/whynot/dto/comment/CommentRequestDTO.java
@@ -1,0 +1,12 @@
+package handong.whynot.dto.comment;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CommentRequestDTO {
+
+    private Long postId;
+    private String comment;
+}

--- a/src/main/java/handong/whynot/dto/comment/CommentResponseCode.java
+++ b/src/main/java/handong/whynot/dto/comment/CommentResponseCode.java
@@ -1,0 +1,20 @@
+package handong.whynot.dto.comment;
+
+import handong.whynot.dto.common.ResponseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommentResponseCode implements ResponseCode {
+
+    COMMENT_CREATE_OK(20001, "댓글 [생성]에 성공하였습니다."),
+    COMMENT_DELETE_OK(20002, "댓글 [삭제]에 성공하였습니다."),
+
+
+    COMMENT_DELETE_FAIL_NOT_FOUND(40001, "댓글 [삭제]에 실패하였습니다. - 해당 id 댓글 없음")
+    ;
+
+    private final Integer statusCode;
+    private final String message;
+}

--- a/src/main/java/handong/whynot/dto/comment/CommentResponseDTO.java
+++ b/src/main/java/handong/whynot/dto/comment/CommentResponseDTO.java
@@ -1,6 +1,7 @@
 package handong.whynot.dto.comment;
 
 import handong.whynot.domain.Comment;
+import handong.whynot.dto.account.AccountResponseDTO;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -14,14 +15,15 @@ public class CommentResponseDTO {
 
     private Long commentId;
     private String content;
-    private String writer;
+    private AccountResponseDTO account;
     private LocalDateTime createdDt;
 
     public static CommentResponseDTO of(Comment comment) {
+
         return CommentResponseDTO.builder()
                 .commentId(comment.getId())
                 .content(comment.getContent())
-                .writer(comment.getCreatedBy().getNickname())
+                .account(AccountResponseDTO.of(comment.getCreatedBy()))
                 .createdDt(comment.getCreatedDt())
                 .build();
     }

--- a/src/main/java/handong/whynot/dto/comment/CommentResponseDTO.java
+++ b/src/main/java/handong/whynot/dto/comment/CommentResponseDTO.java
@@ -3,24 +3,26 @@ package handong.whynot.dto.comment;
 import handong.whynot.domain.Comment;
 import lombok.*;
 
-@AllArgsConstructor
-@NoArgsConstructor
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class CommentResponseDTO {
 
-    private Long postId;
-    private Long parentId;
+    private Long commentId;
     private String content;
     private String writer;
+    private LocalDateTime createdDt;
 
     public static CommentResponseDTO of(Comment comment) {
         return CommentResponseDTO.builder()
-                .postId(comment.getPost().getId())
-                .parentId(comment.getParent().getId())
+                .commentId(comment.getId())
                 .content(comment.getContent())
                 .writer(comment.getCreatedBy().getNickname())
+                .createdDt(comment.getCreatedDt())
                 .build();
     }
 

--- a/src/main/java/handong/whynot/exception/comment/CommentNotFoundException.java
+++ b/src/main/java/handong/whynot/exception/comment/CommentNotFoundException.java
@@ -1,0 +1,12 @@
+package handong.whynot.exception.comment;
+
+import handong.whynot.dto.common.ResponseCode;
+import handong.whynot.exception.AbstractBaseException;
+
+
+public class CommentNotFoundException extends AbstractBaseException {
+
+    public CommentNotFoundException(ResponseCode responseCode) {
+        super(responseCode);
+    }
+}

--- a/src/main/java/handong/whynot/handler/CommentExceptionHandler.java
+++ b/src/main/java/handong/whynot/handler/CommentExceptionHandler.java
@@ -1,0 +1,22 @@
+package handong.whynot.handler;
+
+import handong.whynot.dto.comment.CommentResponseCode;
+import handong.whynot.dto.common.ErrorResponseDTO;
+import handong.whynot.exception.comment.CommentNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Slf4j
+@RestControllerAdvice
+public class CommentExceptionHandler {
+
+    @ResponseStatus(NOT_FOUND)
+    @ExceptionHandler(CommentNotFoundException.class)
+    public ErrorResponseDTO commentNotFoundExceptionHandle() {
+        return ErrorResponseDTO.of(CommentResponseCode.COMMENT_DELETE_FAIL_NOT_FOUND, null);
+    }
+}

--- a/src/main/java/handong/whynot/repository/CommentQueryRepository.java
+++ b/src/main/java/handong/whynot/repository/CommentQueryRepository.java
@@ -1,12 +1,14 @@
 package handong.whynot.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import handong.whynot.domain.Account;
 import handong.whynot.domain.Comment;
 import handong.whynot.domain.QComment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -21,8 +23,15 @@ public class CommentQueryRepository {
         return queryFactory.selectFrom(qComment)
                 .where(qComment.post.id.eq(postId))
                 .orderBy(
-                        qComment.parent.id.asc(),
                         qComment.createdDt.asc()
                 ).fetch();
+    }
+
+    public Optional<Comment> findCommentsByAccount(Long commentId, Account account) {
+
+        return Optional.ofNullable(queryFactory.selectFrom(qComment)
+                .where(qComment.id.eq(commentId)
+                        .and(qComment.createdBy.eq(account)))
+                .fetchFirst());
     }
 }

--- a/src/main/java/handong/whynot/service/CommentService.java
+++ b/src/main/java/handong/whynot/service/CommentService.java
@@ -1,8 +1,13 @@
 package handong.whynot.service;
 
+import handong.whynot.domain.Account;
 import handong.whynot.domain.Comment;
+import handong.whynot.domain.Post;
+import handong.whynot.dto.comment.CommentRequestDTO;
+import handong.whynot.dto.comment.CommentResponseCode;
 import handong.whynot.dto.comment.CommentResponseDTO;
 import handong.whynot.dto.post.PostResponseCode;
+import handong.whynot.exception.comment.CommentNotFoundException;
 import handong.whynot.exception.post.PostNotFoundException;
 import handong.whynot.repository.CommentQueryRepository;
 import handong.whynot.repository.CommentRepository;
@@ -23,6 +28,7 @@ public class CommentService {
 
     public List<CommentResponseDTO> getCommentsByPostId(Long postId) {
 
+        // 존재하는 post인지 검증
         postRepository.findById(postId)
                 .orElseThrow(() -> new PostNotFoundException(PostResponseCode.POST_READ_FAIL));
 
@@ -30,5 +36,31 @@ public class CommentService {
         return comments.stream()
                 .map(comment -> CommentResponseDTO.of(comment))
                 .collect(Collectors.toList());
+    }
+
+    public void createComment(CommentRequestDTO requestDTO, Account account) {
+
+        // 존재하는 post인지 검증
+        Post entity = postRepository.findById(requestDTO.getPostId())
+                .orElseThrow(() -> new PostNotFoundException(PostResponseCode.POST_READ_FAIL));
+
+        // 댓글 생성
+        Comment comment = Comment.builder()
+                .post(entity)
+                .content(requestDTO.getComment())
+                .createdBy(account)
+                .build();
+
+        commentRepository.save(comment);
+    }
+
+    public void deleteComment(Long commentId, Account account) {
+
+        // 본인 comment가 존재하는지 검증
+        Comment comment = commentQueryRepository.findCommentsByAccount(commentId, account)
+                .orElseThrow(() -> new CommentNotFoundException(CommentResponseCode.COMMENT_DELETE_FAIL_NOT_FOUND));
+
+        // 댓글 삭제
+        commentRepository.delete(comment);
     }
 }

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -45,7 +45,7 @@ CREATE TABLE `post` (
   `created_dt` datetime DEFAULT NULL,
   `updated_dt` datetime DEFAULT NULL,
   `closed_dt` datetime DEFAULT NULL,
-  `content` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `content` varchar(2500) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `is_recruiting` bit(1) DEFAULT NULL,
   `post_img` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -121,13 +121,11 @@ CREATE TABLE `comment` (
   `updated_dt` datetime DEFAULT NULL,
   `content` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `account_id` bigint DEFAULT NULL,
-  `parent_id` bigint DEFAULT NULL,
   `post_id` bigint DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `FKp41h5al2ajp1q0u6ox3i68w61` (`account_id`),
   KEY `FKde3rfu96lep00br5ov0mdieyt` (`parent_id`),
   KEY `FKs1slvnkuemjsq2kj4h3vhx7i1` (`post_id`),
-  CONSTRAINT `FKde3rfu96lep00br5ov0mdieyt` FOREIGN KEY (`parent_id`) REFERENCES `comment` (`id`),
   CONSTRAINT `FKp41h5al2ajp1q0u6ox3i68w61` FOREIGN KEY (`account_id`) REFERENCES `account` (`id`),
   CONSTRAINT `FKs1slvnkuemjsq2kj4h3vhx7i1` FOREIGN KEY (`post_id`) REFERENCES `post` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
개발된 API 내역은 다음과 같습니다.

<table> 	
  <tr>    
    <td>Index</td> 	    
    <td>Method</td> 
    <td>Route</td> 
    <td>Description</td> 
  </tr>	
  <tr>	    
    <td>1</td> 	    
    <td>GET</td> 	
    <td>v1/comments/{postId}</td> 	    
    <td>단건 공고에 대한 댓글 조회</td> 	    
  </tr>
  <tr>	    
    <td>2</td> 	    
    <td>POST</td> 	
    <td>v1/comments</td> 	    
    <td>댓글 추가</td> 	    
  </tr> 
  <tr>	    
    <td>3</td> 	    
    <td>DELETE</td> 	
    <td>/v1/comments/{commentId}</td> 	    
    <td>댓글 삭제</td> 	    
  </tr> 
</table>


-----------------------------------------

postman 결과를 함께 첨부합니다.

<댓글 조회>
<img width="426" alt="image" src="https://user-images.githubusercontent.com/42775225/167664763-87b55818-ed11-4bbf-b459-94a6bc1a1387.png">


<br />

-----------------------------------------

<댓글 등록>
<img width="454" alt="image" src="https://user-images.githubusercontent.com/42775225/167640845-acae6a54-483d-41d8-aaf9-bef63fe67b37.png">

<br />

-----------------------------------------

<댓글 삭제>
- 성공
<img width="450" alt="image" src="https://user-images.githubusercontent.com/42775225/167641004-4ca60d72-5d71-4cdb-8bec-123488985bf3.png">

- 실패
<img width="468" alt="image" src="https://user-images.githubusercontent.com/42775225/167641099-dd0be31d-662c-49a4-9f7d-15f638df8b3c.png">

