### PR TITLE
[BE] feat: 인증/인가 jwt 적용

### DIFF
--- a/src/main/java/handong/whynot/api/v1/AccountController.java
+++ b/src/main/java/handong/whynot/api/v1/AccountController.java
@@ -1,4 +1,4 @@
-package handong.whynot.api;
+package handong.whynot.api.v1;
 
 import javax.validation.Valid;
 

--- a/src/main/java/handong/whynot/api/v1/CommentController.java
+++ b/src/main/java/handong/whynot/api/v1/CommentController.java
@@ -1,4 +1,4 @@
-package handong.whynot.api;
+package handong.whynot.api.v1;
 
 import handong.whynot.domain.Account;
 import handong.whynot.dto.account.CurrentAccount;

--- a/src/main/java/handong/whynot/api/v1/JobController.java
+++ b/src/main/java/handong/whynot/api/v1/JobController.java
@@ -1,4 +1,4 @@
-package handong.whynot.api;
+package handong.whynot.api.v1;
 
 import handong.whynot.domain.Job;
 import handong.whynot.dto.job.JobResponseDTO;

--- a/src/main/java/handong/whynot/api/v1/PostController.java
+++ b/src/main/java/handong/whynot/api/v1/PostController.java
@@ -1,4 +1,4 @@
-package handong.whynot.api;
+package handong.whynot.api.v1;
 
 import handong.whynot.domain.Account;
 import handong.whynot.dto.account.CurrentAccount;

--- a/src/main/java/handong/whynot/api/v1/S3Controller.java
+++ b/src/main/java/handong/whynot/api/v1/S3Controller.java
@@ -1,4 +1,4 @@
-package handong.whynot.api;
+package handong.whynot.api.v1;
 
 import handong.whynot.dto.cloud.S3ResponseCode;
 import handong.whynot.dto.cloud.S3ResponseDTO;

--- a/src/main/java/handong/whynot/api/v2/PostControllerV2.java
+++ b/src/main/java/handong/whynot/api/v2/PostControllerV2.java
@@ -1,0 +1,33 @@
+package handong.whynot.api.v2;
+
+import handong.whynot.domain.Account;
+import handong.whynot.dto.common.ResponseDTO;
+import handong.whynot.dto.post.PostRequestDTO;
+import handong.whynot.dto.post.PostResponseCode;
+import handong.whynot.service.AccountService;
+import handong.whynot.service.PostService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+@RestController
+@RequestMapping("/v2/posts")
+@RequiredArgsConstructor
+public class PostControllerV2 {
+
+    private final PostService postService;
+    private final AccountService accountService;
+
+    @Operation(summary = "공고 생성")
+    @PostMapping("")
+    @ResponseStatus(CREATED)
+    public ResponseDTO createPost(@RequestBody PostRequestDTO request) {
+
+        Account account = accountService.getCurrentAccount();
+        postService.createPost(request, account);
+
+        return ResponseDTO.of(PostResponseCode.POST_CREATE_OK);
+    }
+}

--- a/src/main/java/handong/whynot/config/SecurityConfig.java
+++ b/src/main/java/handong/whynot/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -32,10 +33,21 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
                 .cors().configurationSource(corsConfigurationSource())
                 .and()
                 .authorizeRequests()
-                .anyRequest().permitAll()
+                    // Account
+                    .antMatchers("/v1/login", "/v1/sign-up", "/v1/check-email-token", "/v1/resend-token",
+                            "/v1/check-email-duplicate", "/v1/check-nickname-duplicate", "/v2/sign-in").permitAll()
+
+                    // Post
+                    .antMatchers(HttpMethod.GET,"/v1/posts/**", "/v1/comments/**", "/v2/posts/**").permitAll()
+                    .antMatchers("/v1/posts/favorite/**", "/v1/posts/apply/**", "/v1/posts/own/**", "/v2/posts/**").hasRole("USER")
+
+                    // Swagger
+                    .antMatchers(HttpMethod.GET,"/v1/posts/**", "/v1/comments/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                    .anyRequest().authenticated()
+
                 .and()
-                .addFilterBefore(customAuthorizationFilter, UsernamePasswordAuthenticationFilter.class)
-                .exceptionHandling().authenticationEntryPoint(customAuthenticationEntryPoint)
+                    .addFilterAfter(customAuthorizationFilter, UsernamePasswordAuthenticationFilter.class)
+                    .exceptionHandling().authenticationEntryPoint(customAuthenticationEntryPoint)
         ;
 
         // 예외처리 필터 등록

--- a/src/main/java/handong/whynot/dto/account/UserAccount.java
+++ b/src/main/java/handong/whynot/dto/account/UserAccount.java
@@ -11,9 +11,15 @@ import java.util.List;
 public class UserAccount extends User {
 
     private Account account;
+    private String accountId;
 
     public UserAccount(Account account) {
         super(account.getNickname(), account.getPassword(), List.of(new SimpleGrantedAuthority("ROLE_USER")));
         this.account = account;
+    }
+
+    public UserAccount(String accountId) {
+        super(accountId, "", List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        this.accountId = accountId;
     }
 }

--- a/src/main/java/handong/whynot/filter/CustomAuthorizationFilter.java
+++ b/src/main/java/handong/whynot/filter/CustomAuthorizationFilter.java
@@ -65,6 +65,9 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
 
             filterChain.doFilter(request, response);
 
+        } catch (AccountTokenExpiredException e) {
+            // 만료된 토큰인 경우
+            throw new AccountTokenExpiredException(AccountResponseCode.ACCOUNT_TOKEN_EXPIRED);
         } catch (Exception e) {
             // 비정상 토큰인 경우
             throw new AccountNotVerifiedException(AccountResponseCode.ACCOUNT_TOKEN_EXPIRED);

--- a/src/main/java/handong/whynot/filter/CustomAuthorizationFilter.java
+++ b/src/main/java/handong/whynot/filter/CustomAuthorizationFilter.java
@@ -10,7 +10,6 @@ import handong.whynot.exception.account.AccountTokenExpiredException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -22,8 +21,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.List;
 
 @Slf4j
 @Component
@@ -37,31 +35,30 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
 
         String authorization = request.getHeader("Authorization");
 
-        // 토큰이 없는 경우 (Forbidden Exception)
-        if (Objects.isNull(authorization)) {
-            throw new AccountNotVerifiedException(AccountResponseCode.ACCOUNT_FORBIDDEN);
-        }
-
         try {
-            SignedJWT signedJWT = SignedJWT.parse(authorization);
+            // 인증 필요한 요청이 아닌 경우 bypass
+            if (StringUtils.isNotBlank(authorization)) {
 
-            // jwt Secret 검증
-            signedJWT.verify(new MACVerifier(jwtSecret));
+                SignedJWT signedJWT = SignedJWT.parse(authorization);
 
-            // jwt ExpiredTime 검증
-            JWTClaimsSet jwtClaimsSet = signedJWT.getJWTClaimsSet();
-            LocalDateTime tokenExpiredTime = LocalDateTime.ofInstant(jwtClaimsSet.getExpirationTime().toInstant(), ZoneOffset.UTC);
+                // jwt Secret 검증
+                signedJWT.verify(new MACVerifier(jwtSecret));
 
-            if (tokenExpiredTime.isBefore(LocalDateTime.now())) {  // 지금보다 과거이면 true
-                throw new AccountTokenExpiredException(AccountResponseCode.ACCOUNT_TOKEN_EXPIRED);
+                // jwt ExpiredTime 검증
+                JWTClaimsSet jwtClaimsSet = signedJWT.getJWTClaimsSet();
+                LocalDateTime tokenExpiredTime = LocalDateTime.ofInstant(jwtClaimsSet.getExpirationTime().toInstant(), ZoneOffset.UTC);
+
+                if (tokenExpiredTime.isBefore(LocalDateTime.now())) {  // 지금보다 과거이면 true
+                    throw new AccountTokenExpiredException(AccountResponseCode.ACCOUNT_TOKEN_EXPIRED);
+                }
+
+                String accountId = jwtClaimsSet.getSubject();
+                UserAccount userAccount = new UserAccount(accountId);
+                UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                        new UsernamePasswordAuthenticationToken(userAccount, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+                SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
             }
-
-            String accountId = jwtClaimsSet.getSubject();
-            UserAccount userAccount = new UserAccount(accountId);
-            UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
-                    new UsernamePasswordAuthenticationToken(userAccount, null, Collections.singletonList(new SimpleGrantedAuthority("USER")));
-
-            SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
 
             filterChain.doFilter(request, response);
 
@@ -70,31 +67,7 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
             throw new AccountTokenExpiredException(AccountResponseCode.ACCOUNT_TOKEN_EXPIRED);
         } catch (Exception e) {
             // 비정상 토큰인 경우
-            throw new AccountNotVerifiedException(AccountResponseCode.ACCOUNT_TOKEN_EXPIRED);
+            throw new AccountNotVerifiedException(AccountResponseCode.ACCOUNT_FORBIDDEN);
         }
-    }
-
-    /**
-     * JWT 토큰 검증 예외 화이트리스트
-     *
-     * @param request
-     * @return
-     */
-    @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getRequestURI();
-
-        return StringUtils.equals(path, "/")
-                // Account
-                || StringUtils.equals(path, "/v2/sign-in")
-
-                // Post
-                || (StringUtils.equals(path, "/v2/posts") && HttpMethod.GET.matches(request.getMethod()))
-                || (path.matches("^/v2/posts/\\d+$") && HttpMethod.GET.matches(request.getMethod()))
-
-                // Swagger
-                || path.matches("^/swagger-ui/.*")
-                || path.matches("^/v3/api-docs.*")
-                ;
     }
 }

--- a/src/main/java/handong/whynot/filter/CustomAuthorizationFilter.java
+++ b/src/main/java/handong/whynot/filter/CustomAuthorizationFilter.java
@@ -1,0 +1,97 @@
+package handong.whynot.filter;
+
+import com.nimbusds.jose.crypto.MACVerifier;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import handong.whynot.dto.account.AccountResponseCode;
+import handong.whynot.dto.account.UserAccount;
+import handong.whynot.exception.account.AccountNotVerifiedException;
+import handong.whynot.exception.account.AccountTokenExpiredException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Objects;
+
+@Slf4j
+@Component
+public class CustomAuthorizationFilter extends OncePerRequestFilter {
+
+    @Value("${jwt.secretKey}")
+    private String jwtSecret;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
+
+        String authorization = request.getHeader("Authorization");
+
+        // 토큰이 없는 경우 (Forbidden Exception)
+        if (Objects.isNull(authorization)) {
+            throw new AccountNotVerifiedException(AccountResponseCode.ACCOUNT_FORBIDDEN);
+        }
+
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(authorization);
+
+            // jwt Secret 검증
+            signedJWT.verify(new MACVerifier(jwtSecret));
+
+            // jwt ExpiredTime 검증
+            JWTClaimsSet jwtClaimsSet = signedJWT.getJWTClaimsSet();
+            LocalDateTime tokenExpiredTime = LocalDateTime.ofInstant(jwtClaimsSet.getExpirationTime().toInstant(), ZoneOffset.UTC);
+
+            if (tokenExpiredTime.isBefore(LocalDateTime.now())) {  // 지금보다 과거이면 true
+                throw new AccountTokenExpiredException(AccountResponseCode.ACCOUNT_TOKEN_EXPIRED);
+            }
+
+            String accountId = jwtClaimsSet.getSubject();
+            UserAccount userAccount = new UserAccount(accountId);
+            UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                    new UsernamePasswordAuthenticationToken(userAccount, null, Collections.singletonList(new SimpleGrantedAuthority("USER")));
+
+            SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+
+            filterChain.doFilter(request, response);
+
+        } catch (Exception e) {
+            // 비정상 토큰인 경우
+            throw new AccountTokenExpiredException(AccountResponseCode.ACCOUNT_TOKEN_EXPIRED);
+        }
+    }
+
+    /**
+     * JWT 토큰 검증 예외 화이트리스트
+     *
+     * @param request
+     * @return
+     */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+
+        return StringUtils.equals(path, "/")
+                // Account
+                || StringUtils.equals(path, "/v2/sign-in")
+
+                // Post
+                || (StringUtils.equals(path, "/v2/posts") && HttpMethod.GET.matches(request.getMethod()))
+                || (path.matches("^/v2/posts/\\d+$") && HttpMethod.GET.matches(request.getMethod()))
+
+                // Swagger
+                || path.matches("^/swagger-ui/.*")
+                || path.matches("^/v3/api-docs.*")
+                ;
+    }
+}

--- a/src/main/java/handong/whynot/filter/CustomAuthorizationFilter.java
+++ b/src/main/java/handong/whynot/filter/CustomAuthorizationFilter.java
@@ -67,7 +67,7 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
 
         } catch (Exception e) {
             // 비정상 토큰인 경우
-            throw new AccountTokenExpiredException(AccountResponseCode.ACCOUNT_TOKEN_EXPIRED);
+            throw new AccountNotVerifiedException(AccountResponseCode.ACCOUNT_TOKEN_EXPIRED);
         }
     }
 

--- a/src/main/java/handong/whynot/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/handong/whynot/filter/ExceptionHandlerFilter.java
@@ -1,0 +1,74 @@
+package handong.whynot.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import handong.whynot.dto.account.AccountResponseCode;
+import handong.whynot.dto.common.ErrorResponseDTO;
+import handong.whynot.dto.common.ResponseCode;
+import handong.whynot.exception.account.AccountNotVerifiedException;
+import handong.whynot.exception.account.AccountTokenExpiredException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.commons.codec.CharEncoding.UTF_8;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (AccountNotVerifiedException ex) {
+            log.error("jwt 토큰이 없습니다.");
+            setErrorResponse(ex.getResponseCode(), HttpStatus.BAD_REQUEST, response, ex);
+        } catch (AccountTokenExpiredException ex) {
+            log.error("만료된 토큰입니다.");
+            setErrorResponse(ex.getResponseCode(), HttpStatus.BAD_REQUEST, response, ex);
+        } catch (Exception ex) {
+            log.error("Exception: {}", ex.getMessage());
+            setErrorResponse(AccountResponseCode.ACCOUNT_FORBIDDEN, HttpStatus.BAD_REQUEST, response, ex);
+        }
+    }
+
+    public void setErrorResponse(ResponseCode responseCode, HttpStatus status,
+                                 HttpServletResponse response, Throwable ex) {
+
+        List<String> errorMessage = new ArrayList<>();
+        if(Objects.isNull(ex.getMessage())) {
+            errorMessage = null;
+        } else {
+            errorMessage.add(ex.getMessage());
+        }
+
+        ErrorResponseDTO responseMessage = ErrorResponseDTO.of(responseCode, errorMessage);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8);
+
+        response.setStatus(status.value());
+
+        try {
+            response.getWriter().write(objectMapper.writeValueAsString(responseMessage));
+        } catch (IOException e) {
+            response.setStatus(INTERNAL_SERVER_ERROR.value());
+            log.error("[ExceptionHandlerFilter] Json 생성에 실패하였습니다. {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/handong/whynot/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/handong/whynot/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,48 @@
+package handong.whynot.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import handong.whynot.dto.account.AccountResponseCode;
+import handong.whynot.dto.common.ErrorResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.commons.codec.CharEncoding.UTF_8;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) {
+
+        final ErrorResponseDTO responseMessage = ErrorResponseDTO.of(
+                AccountResponseCode.ACCOUNT_FORBIDDEN, List.of("API 접근에 실패하였습니다. 권한을 확인해주세요")
+        );
+
+        response.setCharacterEncoding(UTF_8);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        response.setStatus(BAD_REQUEST.value());
+
+        try {
+            response.getWriter().write(objectMapper.writeValueAsString(responseMessage));
+        } catch (IOException e) {
+            response.setStatus(INTERNAL_SERVER_ERROR.value());
+            log.error("[ExceptionHandlerFilter] Json 생성에 실패하였습니다. {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/handong/whynot/handler/LoginFailureHandler.java
+++ b/src/main/java/handong/whynot/handler/LoginFailureHandler.java
@@ -30,7 +30,7 @@ public class LoginFailureHandler implements AuthenticationFailureHandler {
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
-                                        AuthenticationException exception) throws IOException {
+                                        AuthenticationException exception) {
         ErrorResponseDTO responseMessage = ErrorResponseDTO.of(AccountResponseCode.ACCOUNT_NOT_VALID, null);
 
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/handong/whynot/service/AccountService.java
+++ b/src/main/java/handong/whynot/service/AccountService.java
@@ -14,6 +14,7 @@ import handong.whynot.repository.AccountQueryRepository;
 import handong.whynot.repository.AccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -154,5 +155,12 @@ public class AccountService implements UserDetailsService {
         if (account != null) {
             throw new AccountAlreadyExistNicknameException(AccountResponseCode.ACCOUNT_ALREADY_EXIST_NICKNAME);
         }
+    }
+
+    public Account getCurrentAccount() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Account account = accountRepository.findById(Long.valueOf(authentication.getName()))
+                .orElseThrow(() -> new AccountNotFoundException(AccountResponseCode.ACCOUNT_READ_FAIL));
+        return account;
     }
 }

--- a/src/test/java/handong/whynot/api/AccountControllerTest.java
+++ b/src/test/java/handong/whynot/api/AccountControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 
+import handong.whynot.api.v1.AccountController;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/src/test/java/handong/whynot/api/CommentControllerTest.java
+++ b/src/test/java/handong/whynot/api/CommentControllerTest.java
@@ -1,6 +1,7 @@
 package handong.whynot.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import handong.whynot.api.v1.CommentController;
 import handong.whynot.repository.AccountRepository;
 import handong.whynot.service.CommentService;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/handong/whynot/api/PostControllerTest.java
+++ b/src/test/java/handong/whynot/api/PostControllerTest.java
@@ -1,6 +1,7 @@
 package handong.whynot.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import handong.whynot.api.v1.PostController;
 import handong.whynot.common.WithMockCustomUser;
 import handong.whynot.domain.Account;
 import handong.whynot.domain.Post;


### PR DESCRIPTION
인증/인가 방식 논의를 거친 내용을 정리하여 pr을 드립니다.

<< jwt 인증 과정 >>
1. Filter 레벨에서 자체적으로 등록한 `CustomAuthorizationFilter` 를 선 방문
2. 화이트 리스트에 해당하는 path라면 bypass. (5번으로 이동)
3. jwt토큰 검증 (secret값, 만료시간)
4. SecurityContextHolder에 UserAccount 객체 담음
5. Controller도착 후 서비스 로직 처리 (다음 pr에서 User획득하는 부분 추가 예정)
* 3번, 4번 과정에서 예외 발생 시 `ExceptionHandlerFilter` 에서 예외 핸들링.

- `SecurityConfig` : permitAll()로 변경 및 예외처리 필터 등록
- `UserAccount` : ID값(String)으로 생성자 만듬
- `CustomAuthorizationFilter` : jwt검증 및 필터 화이트 리스트 처리
- `ExceptionHandlerFilter` : filter단 예외처리