### PR TITLE
[BE] jwt토큰 발행 및 로그인 & 사용자 정보조회 API

### DIFF
--- a/src/main/java/handong/whynot/api/v2/AccountControllerV2.java
+++ b/src/main/java/handong/whynot/api/v2/AccountControllerV2.java
@@ -1,0 +1,48 @@
+package handong.whynot.api.v2;
+
+import handong.whynot.domain.Account;
+import handong.whynot.dto.account.AccountResponseDTO;
+import handong.whynot.dto.account.SignInRequestDTO;
+import handong.whynot.dto.account.TokenResponseDTO;
+import handong.whynot.service.AccountService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2")
+public class AccountControllerV2 {
+
+    private final AccountService accountService;
+
+    @PostMapping("/sign-in")
+    public TokenResponseDTO signIn(@RequestBody @Valid SignInRequestDTO signInRequest, HttpServletResponse response) {
+
+        TokenResponseDTO tokenResponseDTO = accountService.signIn(signInRequest);
+
+        Cookie cookie = new Cookie("refresh", tokenResponseDTO.getRefreshToken());
+        cookie.setHttpOnly(true);    // 자바스크립트로 쿠키를 조회하는 것을 막는 옵션
+
+        response.addCookie(cookie);
+
+        return tokenResponseDTO;
+    }
+
+    @Operation(summary = "계정 정보 조회")
+    @GetMapping("/account/info")
+    public AccountResponseDTO getAccountInfo() {
+        Account account = accountService.getCurrentAccount();
+
+        return AccountResponseDTO.builder()
+                .id(account.getId())
+                .email(account.getEmail())
+                .nickname(account.getNickname())
+                .profileImg(account.getProfileImg())
+                .build();
+    }
+}

--- a/src/main/java/handong/whynot/config/SecurityConfig.java
+++ b/src/main/java/handong/whynot/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -58,6 +59,12 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
     public void configure(WebSecurity web) {
         web.ignoring()
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+    }
+
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
     }
 
     @Bean

--- a/src/main/java/handong/whynot/dto/account/AccountResponseCode.java
+++ b/src/main/java/handong/whynot/dto/account/AccountResponseCode.java
@@ -30,7 +30,8 @@ public enum AccountResponseCode implements ResponseCode {
 
     ACCOUNT_VALID_DUPLICATE(20007, "사용 가능한 인자입니다."),
     ACCOUNT_LOGOUT_SUCCESS(20008, "로그아웃 성공하였습니다."),
-    ACCOUNT_TOKEN_EXPIRED(40011, "만료된 토큰입니다.");
+    ACCOUNT_TOKEN_EXPIRED(40011, "만료된 토큰입니다."),
+    ACCOUNT_NOT_VALID_TOKEN_SECRET(40012, "올바르지 않은 jwt 토큰 시크릿입니다.");
 
     private final Integer statusCode;
     private final String message;

--- a/src/main/java/handong/whynot/dto/account/SignInRequestDTO.java
+++ b/src/main/java/handong/whynot/dto/account/SignInRequestDTO.java
@@ -1,5 +1,6 @@
 package handong.whynot.dto.account;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -7,6 +8,7 @@ import javax.validation.constraints.NotBlank;
 
 @Getter
 @Setter
+@AllArgsConstructor
 public class SignInRequestDTO {
 
     @NotBlank // null 과 "" 과 " " 모두 허용X

--- a/src/main/java/handong/whynot/dto/account/SignInRequestDTO.java
+++ b/src/main/java/handong/whynot/dto/account/SignInRequestDTO.java
@@ -1,0 +1,17 @@
+package handong.whynot.dto.account;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+public class SignInRequestDTO {
+
+    @NotBlank // null 과 "" 과 " " 모두 허용X
+    private String email;
+
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/handong/whynot/dto/account/TokenResponseDTO.java
+++ b/src/main/java/handong/whynot/dto/account/TokenResponseDTO.java
@@ -1,0 +1,26 @@
+package handong.whynot.dto.account;
+
+import handong.whynot.domain.Account;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TokenResponseDTO {
+
+    private String accessToken;
+
+    private String refreshToken;
+
+    private AccountResponseDTO accountResponseDTO;
+
+    public static TokenResponseDTO of(Account account, String accessToken, String refreshToken){
+        return TokenResponseDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accountResponseDTO(AccountResponseDTO.of(account))
+                .build();
+    }
+}

--- a/src/main/java/handong/whynot/handler/AccountExceptionHandler.java
+++ b/src/main/java/handong/whynot/handler/AccountExceptionHandler.java
@@ -2,6 +2,7 @@ package handong.whynot.handler;
 
 import handong.whynot.dto.common.ErrorResponseDTO;
 import handong.whynot.dto.account.AccountResponseCode;
+import handong.whynot.dto.common.ResponseCode;
 import handong.whynot.exception.account.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -41,7 +42,7 @@ public class AccountExceptionHandler {
 
     @ResponseStatus(BAD_REQUEST)
     @ExceptionHandler(AccountNotValidToken.class)
-    public ErrorResponseDTO notValidTokenExceptionHandle() {
-        return ErrorResponseDTO.of(AccountResponseCode.ACCOUNT_NOT_VALID_TOKEN, null);
+    public ErrorResponseDTO notValidTokenExceptionHandle(ResponseCode code) {
+        return ErrorResponseDTO.of(code, null);
     }
 }

--- a/src/main/java/handong/whynot/service/SignInTokenGenerator.java
+++ b/src/main/java/handong/whynot/service/SignInTokenGenerator.java
@@ -6,6 +6,8 @@ import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.MACSigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import handong.whynot.dto.account.AccountResponseCode;
+import handong.whynot.exception.account.AccountNotValidToken;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -38,21 +40,24 @@ public class SignInTokenGenerator {
         return signInToken(String.valueOf(userId), Date.from(expirationTime.toInstant(ZoneOffset.UTC)), audience);
     }
 
-    @SneakyThrows
     private String signInToken(String userId, Date expirationTime, String audience) {
-        JWSSigner jwsSigner = new MACSigner(jwtSecret);
-        JWSHeader jwsHeader = new JWSHeader(JWSAlgorithm.HS256);
+        try {
+            JWSSigner jwsSigner = new MACSigner(jwtSecret);
+            JWSHeader jwsHeader = new JWSHeader(JWSAlgorithm.HS256);
 
-        JWTClaimsSet jwtClaimsSet = claimsSetForSignInToken(userId, expirationTime, audience);
+            JWTClaimsSet jwtClaimsSet = claimsSetForSignInToken(userId, expirationTime, audience);
 
 
-        SignedJWT signedJWT = new SignedJWT(
-                jwsHeader,
-                jwtClaimsSet
-        );
+            SignedJWT signedJWT = new SignedJWT(
+                    jwsHeader,
+                    jwtClaimsSet
+            );
 
-        signedJWT.sign(jwsSigner);
-        return signedJWT.serialize();
+            signedJWT.sign(jwsSigner);
+            return signedJWT.serialize();
+        } catch (Exception e) {
+            throw new AccountNotValidToken(AccountResponseCode.ACCOUNT_NOT_VALID_TOKEN_SECRET);
+        }
     }
 
     private JWTClaimsSet claimsSetForSignInToken(String userId, Date expirationTime, String audience) {

--- a/src/main/java/handong/whynot/service/SignInTokenGenerator.java
+++ b/src/main/java/handong/whynot/service/SignInTokenGenerator.java
@@ -1,0 +1,66 @@
+package handong.whynot.service;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+
+@Component
+public class SignInTokenGenerator {
+
+    @Value("${jwt.secretKey}")
+    private String jwtSecret;
+
+    @Value("${jwt.expiredTime.access-token}")
+    private Long accessExpiredTime;
+
+    @Value("${jwt.expiredTime.refresh-token}")
+    private Long refreshExpiredTime;
+
+    public String accessToken(Long userId) {
+        return signInToken(userId, LocalDateTime.now().plusMinutes(accessExpiredTime), "access");
+    }
+
+    public String refreshToken(Long userId) {
+        return signInToken(userId, LocalDateTime.now().plusMinutes(refreshExpiredTime), "refresh");
+    }
+
+    private String signInToken(Long userId, LocalDateTime expirationTime, String audience) {
+        return signInToken(String.valueOf(userId), Date.from(expirationTime.toInstant(ZoneOffset.UTC)), audience);
+    }
+
+    @SneakyThrows
+    private String signInToken(String userId, Date expirationTime, String audience) {
+        JWSSigner jwsSigner = new MACSigner(jwtSecret);
+        JWSHeader jwsHeader = new JWSHeader(JWSAlgorithm.HS256);
+
+        JWTClaimsSet jwtClaimsSet = claimsSetForSignInToken(userId, expirationTime, audience);
+
+
+        SignedJWT signedJWT = new SignedJWT(
+                jwsHeader,
+                jwtClaimsSet
+        );
+
+        signedJWT.sign(jwsSigner);
+        return signedJWT.serialize();
+    }
+
+    private JWTClaimsSet claimsSetForSignInToken(String userId, Date expirationTime, String audience) {
+        return new JWTClaimsSet.Builder()
+                .subject(userId)                  // 사용자
+                .expirationTime(expirationTime)   // 만료시간
+                .audience(audience)               // 의도된 수신자
+                .build();
+    }
+}
+

--- a/src/test/java/handong/whynot/api/v2/AccountControllerV2Test.java
+++ b/src/test/java/handong/whynot/api/v2/AccountControllerV2Test.java
@@ -1,0 +1,74 @@
+package handong.whynot.api.v2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import handong.whynot.config.AppConfig;
+import handong.whynot.config.SecurityConfig;
+import handong.whynot.dto.account.AccountResponseDTO;
+import handong.whynot.dto.account.SignInRequestDTO;
+import handong.whynot.dto.account.TokenResponseDTO;
+import handong.whynot.handler.CustomAuthenticationEntryPoint;
+import handong.whynot.repository.AccountRepository;
+import handong.whynot.service.AccountService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AccountControllerV2.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@Import({ SecurityConfig.class, AppConfig.class })
+class AccountControllerV2Test {
+
+    @MockBean
+    private AccountService accountService;
+    @MockBean
+    private AccountRepository accountRepository;
+    @MockBean
+    private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Value("${test.user.name}")
+    private String username;
+
+    @Value("${test.user.password}")
+    private String password;
+
+    @Test
+    @DisplayName("사용자 로그인 성공 테스트")
+    void signInWithValidInput() throws Exception {
+        final SignInRequestDTO signInRequestDTO = new SignInRequestDTO(username, password);
+
+        TokenResponseDTO tokenResponseDTO = TokenResponseDTO.builder()
+                .accessToken("access-token")
+                .refreshToken("refresh-token")
+                .accountResponseDTO(AccountResponseDTO.builder().build())
+                .build();
+
+        when(accountService.signIn(any())).thenReturn(tokenResponseDTO);
+
+        mockMvc.perform(post("/v2/sign-in")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(signInRequestDTO)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("accessToken").value("access-token"));
+    }
+}

--- a/src/test/java/handong/whynot/util/ImageTypeTest.java
+++ b/src/test/java/handong/whynot/util/ImageTypeTest.java
@@ -1,21 +1,13 @@
 package handong.whynot.util;
 
-import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import javax.activation.MimetypesFileTypeMap;
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ImageTypeTest {
 


### PR DESCRIPTION
로그인에 성공했을 시 jwt 토큰 발행하는 API 추가하였습니다.
이후 획득한 토큰으로 사용자 정보조회 API를 통해 확인(테스트) 가능합니다.

그리고 기본적인 MVC테스트 코드 작성해보았는데요.
Service 테스트 코드도 함께 작성해서 올려볼게요!

우선 구현된 기능 pr 드립니다.