### PR TITLE
[BE] feat: 인증/인가 변경으로 인한 Post API v2 게시

### DIFF
--- a/src/main/java/handong/whynot/api/v1/PostController.java
+++ b/src/main/java/handong/whynot/api/v1/PostController.java
@@ -21,6 +21,7 @@ public class PostController {
 
     private final PostService postService;
 
+    @Deprecated
     @Operation(summary = "공고 전체 조회")
     @GetMapping("")
     public List<PostResponseDTO> getPosts(
@@ -30,6 +31,7 @@ public class PostController {
         return postService.getPostsByParam(status, jobTypeList);
     }
 
+    @Deprecated
     @Operation(summary = "공고 생성")
     @PostMapping("")
     @ResponseStatus(CREATED)
@@ -40,12 +42,14 @@ public class PostController {
         return ResponseDTO.of(PostResponseCode.POST_CREATE_OK);
     }
 
+    @Deprecated
     @Operation(summary = "공고 단건 조회")
     @GetMapping("/{postId}")
     public PostResponseDTO getPost(@PathVariable Long postId) {
         return postService.getPost(postId);
     }
 
+    @Deprecated
     @Operation(summary = "공고 단건 삭제")
     @DeleteMapping("/{postId}")
     public ResponseDTO deletePost(@PathVariable Long postId, @CurrentAccount Account account) {
@@ -55,6 +59,7 @@ public class PostController {
         return ResponseDTO.of(PostResponseCode.POST_DELETE_OK);
     }
 
+    @Deprecated
     @Operation(summary = "공고 단건 수정")
     @PutMapping("/{postId}")
     public ResponseDTO updatePost(@PathVariable Long postId, @RequestBody PostRequestDTO request, @CurrentAccount Account account) {
@@ -64,6 +69,7 @@ public class PostController {
         return ResponseDTO.of(PostResponseCode.POST_UPDATE_OK);
     }
 
+    @Deprecated
     @Operation(summary = "‘좋아요’ 공고 전체 조회")
     @GetMapping("/favorite")
     public List<PostResponseDTO> getFavorite(@CurrentAccount Account account) {
@@ -71,6 +77,7 @@ public class PostController {
         return postService.getFavorites(account);
     }
 
+    @Deprecated
     @Operation(summary = "‘좋아요’ 공고 단건 생성 (좋아요 on)")
     @PostMapping("/favorite/{postId}")
     @ResponseStatus(CREATED)
@@ -81,6 +88,7 @@ public class PostController {
         return ResponseDTO.of(PostResponseCode.POST_CREATE_FAVORITE_OK);
     }
 
+    @Deprecated
     @Operation(summary = "‘좋아요’ 공고 단건 삭제 (좋아요 off)")
     @DeleteMapping("/favorite/{postId}")
     public ResponseDTO deleteFavorite(@PathVariable Long postId, @CurrentAccount Account account) {
@@ -90,6 +98,7 @@ public class PostController {
         return ResponseDTO.of(PostResponseCode.POST_DELETE_FAVORITE_OK);
     }
 
+    @Deprecated
     @Operation(summary = "신청한 공고 전체 조회")
     @GetMapping("/apply")
     public List<PostResponseDTO> getApplys(@CurrentAccount Account account) {
@@ -97,6 +106,7 @@ public class PostController {
         return postService.getApplys(account);
     }
 
+    @Deprecated
     @Operation(summary = "신청한 공고 단건 생성 (지원) + 이메일 알림")
     @PostMapping("/apply/{postId}")
     @ResponseStatus(CREATED)
@@ -107,6 +117,7 @@ public class PostController {
         return ResponseDTO.of(PostResponseCode.POST_CREATE_APPLY_OK);
     }
 
+    @Deprecated
     @Operation(summary = "신청한 공고 단건 삭제 (지원 취소) + 이메일 알림")
     @DeleteMapping("/apply/{postId}")
     public ResponseDTO deleteApply(@PathVariable Long postId, @CurrentAccount Account account) {
@@ -116,6 +127,7 @@ public class PostController {
         return ResponseDTO.of(PostResponseCode.POST_DELETE_APPLY_OK);
     }
 
+    @Deprecated
     @Operation(summary = "생성한 공고 전체 조회성")
     @GetMapping("/own")
     public List<PostResponseDTO> getMyPosts(@CurrentAccount Account account) {
@@ -123,6 +135,7 @@ public class PostController {
         return postService.getMyPosts(account);
     }
 
+    @Deprecated
     @Operation(summary = "공고 모집 상태변경")
     @PostMapping("/own/{postId}")
     public ResponseDTO changeRecruiting(@PathVariable Long postId, @RequestBody PostRecruitDTO request, @CurrentAccount Account account) {

--- a/src/main/java/handong/whynot/api/v2/PostControllerV2.java
+++ b/src/main/java/handong/whynot/api/v2/PostControllerV2.java
@@ -2,13 +2,14 @@ package handong.whynot.api.v2;
 
 import handong.whynot.domain.Account;
 import handong.whynot.dto.common.ResponseDTO;
-import handong.whynot.dto.post.PostRequestDTO;
-import handong.whynot.dto.post.PostResponseCode;
+import handong.whynot.dto.post.*;
 import handong.whynot.service.AccountService;
 import handong.whynot.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
@@ -29,5 +30,109 @@ public class PostControllerV2 {
         postService.createPost(request, account);
 
         return ResponseDTO.of(PostResponseCode.POST_CREATE_OK);
+    }
+
+    @Operation(summary = "공고 단건 조회")
+    @GetMapping("/{postId}")
+    public PostResponseDTO getPost(@PathVariable Long postId) {
+        return postService.getPost(postId);
+    }
+
+    @Operation(summary = "공고 단건 삭제")
+    @DeleteMapping("/{postId}")
+    public ResponseDTO deletePost(@PathVariable Long postId) {
+
+        Account account = accountService.getCurrentAccount();
+        postService.deletePost(postId, account);
+
+        return ResponseDTO.of(PostResponseCode.POST_DELETE_OK);
+    }
+
+    @Operation(summary = "공고 단건 수정")
+    @PutMapping("/{postId}")
+    public ResponseDTO updatePost(@PathVariable Long postId, @RequestBody PostRequestDTO request) {
+
+        Account account = accountService.getCurrentAccount();
+        postService.updatePost(postId, request, account);
+
+        return ResponseDTO.of(PostResponseCode.POST_UPDATE_OK);
+    }
+
+    @Operation(summary = "‘좋아요’ 공고 전체 조회")
+    @GetMapping("/favorite")
+    public List<PostResponseDTO> getFavorite() {
+
+        Account account = accountService.getCurrentAccount();
+
+        return postService.getFavorites(account);
+    }
+
+    @Operation(summary = "‘좋아요’ 공고 단건 생성 (좋아요 on)")
+    @PostMapping("/favorite/{postId}")
+    @ResponseStatus(CREATED)
+    public ResponseDTO createFavorite(@PathVariable Long postId) {
+
+        Account account = accountService.getCurrentAccount();
+        postService.createFavorite(postId, account);
+
+        return ResponseDTO.of(PostResponseCode.POST_CREATE_FAVORITE_OK);
+    }
+
+    @Operation(summary = "‘좋아요’ 공고 단건 삭제 (좋아요 off)")
+    @DeleteMapping("/favorite/{postId}")
+    public ResponseDTO deleteFavorite(@PathVariable Long postId) {
+
+        Account account = accountService.getCurrentAccount();
+        postService.deleteFavorite(postId, account);
+
+        return ResponseDTO.of(PostResponseCode.POST_DELETE_FAVORITE_OK);
+    }
+
+    @Operation(summary = "신청한 공고 전체 조회")
+    @GetMapping("/apply")
+    public List<PostResponseDTO> getApplys() {
+
+        Account account = accountService.getCurrentAccount();
+        return postService.getApplys(account);
+    }
+
+    @Operation(summary = "신청한 공고 단건 생성 (지원) + 이메일 알림")
+    @PostMapping("/apply/{postId}")
+    @ResponseStatus(CREATED)
+    public ResponseDTO createApply(@PathVariable Long postId, @RequestBody PostApplyRequestDTO request) {
+
+        Account account = accountService.getCurrentAccount();
+        postService.createApply(postId, request, account);
+
+        return ResponseDTO.of(PostResponseCode.POST_CREATE_APPLY_OK);
+    }
+
+    @Operation(summary = "신청한 공고 단건 삭제 (지원 취소) + 이메일 알림")
+    @DeleteMapping("/apply/{postId}")
+    public ResponseDTO deleteApply(@PathVariable Long postId) {
+
+        Account account = accountService.getCurrentAccount();
+        postService.deleteApply(postId, account);
+
+        return ResponseDTO.of(PostResponseCode.POST_DELETE_APPLY_OK);
+    }
+
+    @Operation(summary = "생성한 공고 전체 조회성")
+    @GetMapping("/own")
+    public List<PostResponseDTO> getMyPosts() {
+
+        Account account = accountService.getCurrentAccount();
+
+        return postService.getMyPosts(account);
+    }
+
+    @Operation(summary = "공고 모집 상태변경")
+    @PostMapping("/own/{postId}")
+    public ResponseDTO changeRecruiting(@PathVariable Long postId, @RequestBody PostRecruitDTO request) {
+
+        Account account = accountService.getCurrentAccount();
+        postService.changeRecruiting(postId, request, account);
+
+        return ResponseDTO.of(PostResponseCode.POST_END_RECRUIT_OK);
     }
 }


### PR DESCRIPTION
인증/인가 처리 방식 변경으로 인해
기존 `@CurrentAccount` 로 사용자를 획득했던 방식에서
`SecurityContextHolder` 에 있는 인증객체를 통해 사용자를 획득하는 방식으로 변경되었습니다.

POST 도메인 API부터 마이그레이션 시작하였습니다.

테스트는 이메일로 공유드린 postman으로 진행하였습니다.

![image](https://user-images.githubusercontent.com/42775225/178300295-6be83835-92fc-433a-a47a-c654e5a69de7.png)
