### PR TITLE
feat: 테스트 클래스에 JpaMetamodelMappingContext 설정 제거

### DIFF
--- a/src/main/java/handong/whynot/WhynotApplication.java
+++ b/src/main/java/handong/whynot/WhynotApplication.java
@@ -8,11 +8,9 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Slf4j
-@EnableJpaAuditing
 @SpringBootApplication
 public class WhynotApplication {
 

--- a/src/main/java/handong/whynot/config/JpaConfig.java
+++ b/src/main/java/handong/whynot/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package handong.whynot.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/test/java/handong/whynot/api/AccountControllerTest.java
+++ b/src/test/java/handong/whynot/api/AccountControllerTest.java
@@ -16,7 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -30,7 +29,6 @@ import handong.whynot.repository.AccountRepository;
 import handong.whynot.service.AccountService;
 
 @WebMvcTest(AccountController.class)
-@MockBean(JpaMetamodelMappingContext.class)
 @Import({ SecurityConfig.class, AppConfig.class })
 class AccountControllerTest {
 

--- a/src/test/java/handong/whynot/api/CommentControllerTest.java
+++ b/src/test/java/handong/whynot/api/CommentControllerTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
@@ -19,7 +18,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(CommentController.class)
-@MockBean(JpaMetamodelMappingContext.class)
 public class CommentControllerTest {
 
     @MockBean private CommentService commentService;

--- a/src/test/java/handong/whynot/api/PostControllerTest.java
+++ b/src/test/java/handong/whynot/api/PostControllerTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
@@ -42,7 +41,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 
 @WebMvcTest(PostController.class)
-@MockBean(JpaMetamodelMappingContext.class)
 public class PostControllerTest {
 
     @MockBean private PostService postService;

--- a/src/test/java/handong/whynot/api/v2/AccountControllerV2Test.java
+++ b/src/test/java/handong/whynot/api/v2/AccountControllerV2Test.java
@@ -16,12 +16,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -29,7 +27,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AccountControllerV2.class)
-@MockBean(JpaMetamodelMappingContext.class)
 @Import({ SecurityConfig.class, AppConfig.class })
 class AccountControllerV2Test {
 


### PR DESCRIPTION
## 설명

- 테스트 클래스에 JpaMetamodelMappingContext 설정 제거
- 별도 Configuration 파일을 추가하는 방향으로 사용하도록 설정
  - ref: https://giron.tistory.com/127

## 기타

- 테스트 케이스 fail도 조만간 잡을 수 있으면 좋겠습니다 🙂 