### PR TITLE
[BE] OAuth2 추가를 위한 환경 설정 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,10 @@ dependencies {
     // nimbusds
     implementation 'com.nimbusds:nimbus-jose-jwt:9.22'
 
+    // oauth2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/handong/whynot/domain/Account.java
+++ b/src/main/java/handong/whynot/domain/Account.java
@@ -20,10 +20,10 @@ public class Account {
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "email", unique = true)
+    @Column(name = "email")
     private String email;
 
-    @Column(name = "nickname", unique = true)
+    @Column(name = "nickname")
     private String nickname;
 
     @Column(name = "password")
@@ -68,6 +68,7 @@ public class Account {
                 .email(email)
                 .nickname(nickname)
                 .profileImg(profileImg)
+                .authType(authType)
                 .build();
     }
 }

--- a/src/main/java/handong/whynot/domain/Account.java
+++ b/src/main/java/handong/whynot/domain/Account.java
@@ -41,6 +41,10 @@ public class Account {
     @Column(name = "email_check_token_generated_at")
     private LocalDateTime emailCheckTokenGeneratedAt;
 
+    @Column(name = "auth_type")
+    @Enumerated(EnumType.STRING)
+    private AuthType authType;
+
     @Column(name = "joined_at")
     private LocalDateTime joinedAt;
 

--- a/src/main/java/handong/whynot/domain/Account.java
+++ b/src/main/java/handong/whynot/domain/Account.java
@@ -20,10 +20,10 @@ public class Account {
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "email")
+    @Column(name = "email", unique = true)
     private String email;
 
-    @Column(name = "nickname")
+    @Column(name = "nickname", unique = true)
     private String nickname;
 
     @Column(name = "password")

--- a/src/main/java/handong/whynot/domain/AuthType.java
+++ b/src/main/java/handong/whynot/domain/AuthType.java
@@ -1,8 +1,16 @@
 package handong.whynot.domain;
 
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+
 public enum AuthType {
     local,
     google,
     naver,
-    kakao
+    kakao;
+
+    public static Boolean isValidRegistrationId(String registrationId) {
+        return Arrays.stream(AuthType.values()).anyMatch(value -> StringUtils.equals(value.toString(), registrationId));
+    }
 }

--- a/src/main/java/handong/whynot/domain/AuthType.java
+++ b/src/main/java/handong/whynot/domain/AuthType.java
@@ -1,0 +1,8 @@
+package handong.whynot.domain;
+
+public enum AuthType {
+    local,
+    google,
+    naver,
+    kakao
+}

--- a/src/main/java/handong/whynot/dto/account/AccountResponseCode.java
+++ b/src/main/java/handong/whynot/dto/account/AccountResponseCode.java
@@ -32,7 +32,8 @@ public enum AccountResponseCode implements ResponseCode {
     ACCOUNT_LOGOUT_SUCCESS(20008, "로그아웃 성공하였습니다."),
     ACCOUNT_TOKEN_EXPIRED(40011, "만료된 토큰입니다."),
     ACCOUNT_NOT_VALID_TOKEN_SECRET(40012, "올바르지 않은 jwt 토큰 시크릿입니다."),
-    ACCOUNT_OAUTH2_PROCESS_FAILED(40013, "OAuth2 처리 실패하였습니다.");
+    ACCOUNT_OAUTH2_PROCESS_FAILED(40013, "OAuth2 처리 실패하였습니다."),
+    ACCOUNT_OAUTH2_INVALID_REGISTRATION(40014, "지원하지 않는 OAuth2 서버입니다.");
 
     private final Integer statusCode;
     private final String message;

--- a/src/main/java/handong/whynot/dto/account/AccountResponseCode.java
+++ b/src/main/java/handong/whynot/dto/account/AccountResponseCode.java
@@ -31,7 +31,8 @@ public enum AccountResponseCode implements ResponseCode {
     ACCOUNT_VALID_DUPLICATE(20007, "사용 가능한 인자입니다."),
     ACCOUNT_LOGOUT_SUCCESS(20008, "로그아웃 성공하였습니다."),
     ACCOUNT_TOKEN_EXPIRED(40011, "만료된 토큰입니다."),
-    ACCOUNT_NOT_VALID_TOKEN_SECRET(40012, "올바르지 않은 jwt 토큰 시크릿입니다.");
+    ACCOUNT_NOT_VALID_TOKEN_SECRET(40012, "올바르지 않은 jwt 토큰 시크릿입니다."),
+    ACCOUNT_OAUTH2_PROCESS_FAILED(40013, "OAuth2 처리 실패하였습니다.");
 
     private final Integer statusCode;
     private final String message;

--- a/src/main/java/handong/whynot/dto/account/AccountResponseDTO.java
+++ b/src/main/java/handong/whynot/dto/account/AccountResponseDTO.java
@@ -1,6 +1,7 @@
 package handong.whynot.dto.account;
 
 import handong.whynot.domain.Account;
+import handong.whynot.domain.AuthType;
 import lombok.*;
 
 @Getter
@@ -14,6 +15,7 @@ public class AccountResponseDTO {
     private String email;
     private String nickname;
     private String profileImg;
+    private AuthType authType;
 
     public static AccountResponseDTO of(Account account) {
         return AccountResponseDTO.builder()
@@ -21,6 +23,7 @@ public class AccountResponseDTO {
                 .email(account.getEmail())
                 .nickname(account.getNickname())
                 .profileImg(account.getProfileImg())
+                .authType(account.getAuthType())
                 .build();
     }
 }

--- a/src/main/java/handong/whynot/dto/account/UserAccount.java
+++ b/src/main/java/handong/whynot/dto/account/UserAccount.java
@@ -2,24 +2,40 @@ package handong.whynot.dto.account;
 
 import handong.whynot.domain.Account;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.List;
+import java.util.Map;
 
 @Getter
-public class UserAccount extends User {
+@Setter
+public class UserAccount extends User implements OAuth2User {
 
     private Account account;
     private String accountId;
+    private Map<String, Object> attributes;
 
     public UserAccount(Account account) {
-        super(account.getNickname(), account.getPassword(), List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        super(account.getNickname(), account.getPassword() == null ? "" : account.getPassword(), List.of(new SimpleGrantedAuthority("ROLE_USER")));
         this.account = account;
     }
 
     public UserAccount(String accountId) {
         super(accountId, "", List.of(new SimpleGrantedAuthority("ROLE_USER")));
         this.accountId = accountId;
+    }
+
+    @Override
+    public String getName() {
+        return accountId;
+    }
+
+    public static UserAccount create(Account account, Map<String, Object> attributes) {
+        UserAccount userAccount = new UserAccount(account);
+        userAccount.setAttributes(attributes);
+        return userAccount;
     }
 }

--- a/src/main/java/handong/whynot/dto/account/oauth2/GoogleOAuth2UserInfo.java
+++ b/src/main/java/handong/whynot/dto/account/oauth2/GoogleOAuth2UserInfo.java
@@ -1,0 +1,30 @@
+package handong.whynot.dto.account.oauth2;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("picture");
+    }
+}

--- a/src/main/java/handong/whynot/dto/account/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/handong/whynot/dto/account/oauth2/OAuth2UserInfo.java
@@ -1,0 +1,23 @@
+package handong.whynot.dto.account.oauth2;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public abstract String getId();
+
+    public abstract String getName();
+
+    public abstract String getEmail();
+
+    public abstract String getImageUrl();
+}

--- a/src/main/java/handong/whynot/exception/account/OAuth2ProcessingException.java
+++ b/src/main/java/handong/whynot/exception/account/OAuth2ProcessingException.java
@@ -1,0 +1,11 @@
+package handong.whynot.exception.account;
+
+import handong.whynot.dto.common.ResponseCode;
+import handong.whynot.exception.AbstractBaseException;
+
+public class OAuth2ProcessingException extends AbstractBaseException {
+
+    public OAuth2ProcessingException(ResponseCode responseCode) {
+        super(responseCode);
+    }
+}

--- a/src/main/java/handong/whynot/repository/AccountRepository.java
+++ b/src/main/java/handong/whynot/repository/AccountRepository.java
@@ -1,10 +1,7 @@
 package handong.whynot.repository;
 
 import handong.whynot.domain.Account;
-import handong.whynot.domain.AuthType;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
@@ -15,7 +12,4 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
     Account findByEmail(String email);
 
     Account findByNickname(String nickname);
-    Optional<Account> findByEmailAndAuthType(String email, AuthType authType);
-
-
 }

--- a/src/main/java/handong/whynot/repository/AccountRepository.java
+++ b/src/main/java/handong/whynot/repository/AccountRepository.java
@@ -1,7 +1,10 @@
 package handong.whynot.repository;
 
 import handong.whynot.domain.Account;
+import handong.whynot.domain.AuthType;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
@@ -12,5 +15,7 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
     Account findByEmail(String email);
 
     Account findByNickname(String nickname);
+    Optional<Account> findByEmailAndAuthType(String email, AuthType authType);
+
 
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,6 +18,16 @@ server:
         http-only: true
 
 spring:
+  security:
+    oauth2:
+      redirect-uri: http://localhost:3000  # todo: 프론트 주소 나오면 변경
+      client:
+        registration:
+          google:
+            client-id: ${google.client.id}
+            client-secret: ${google.client.secret}
+            scope: ${google.client.scope}
+
   config:
     import: classpath:/whynot-config/env-dev.yml
     activate:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -35,7 +35,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${db.url}/whynot?characterEncoding=UTF-8&serverTimezone=UTC
+    url: jdbc:mysql://${db.url}/whynot?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: ${db.username}
     password: ${db.password}
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,7 +26,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${db.url}/whynot?characterEncoding=UTF-8&serverTimezone=UTC
+    url: jdbc:mysql://${db.url}/whynot?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: ${db.username}
     password: ${db.password}
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,6 +9,16 @@ server:
         http-only: true
 
 spring:
+  security:
+    oauth2:
+      redirect-uri: http://localhost:3000
+      client:
+        registration:
+          google:
+            client-id: ${google.client.id}
+            client-secret: ${google.client.secret}
+            scope: ${google.client.scope}
+
   config:
     import: classpath:/whynot-config/env-local.yml
     activate:

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -7,129 +7,219 @@ DROP TABLE IF EXISTS `post`;
 DROP TABLE IF EXISTS `account`;
 
 
-CREATE TABLE `account` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `email` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `email_check_token` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `email_check_token_generated_at` datetime DEFAULT NULL,
-  `email_verified` bit(1) DEFAULT NULL,
-  `joined_at` datetime DEFAULT NULL,
-  `nickname` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `password` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `profile_img` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `UK_q0uja26qgu1atulenwup9rxyr` (`email`),
-  UNIQUE KEY `UK_s2a5omeaik0sruawqpvs18qfk` (`nickname`)
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `account`
+(
+    `id`                             bigint NOT NULL AUTO_INCREMENT,
+    `email`                          varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+    `email_check_token`              varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+    `email_check_token_generated_at` datetime                                DEFAULT NULL,
+    `email_verified`                 bit(1)                                  DEFAULT NULL,
+    `joined_at`                      datetime                                DEFAULT NULL,
+    `nickname`                       varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+    `password`                       varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+    `profile_img`                    varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+    `auth_type`                      varchar(255),
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `UK_q0uja26qgu1atulenwup9rxyr` (`email`),
+    UNIQUE KEY `UK_s2a5omeaik0sruawqpvs18qfk` (`nickname`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 7
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 LOCK TABLES `account` WRITE;
-INSERT INTO `account` VALUES (1,'gildong@maver.com',NULL,NULL,_binary '',NULL,'Gildong','{bcrypt}$2a$00asdf','https://user-images.githubusercontent.com/42775225/156348135-c44d1de2-c73f-49d9-accf-b0461f0cf740.png'),(2,'whynot-user@email.com',NULL,NULL,_binary '','2022-03-09 07:08:08','whynot-user','{bcrypt}$2a$10$xXkjud45CmBA/rOW0B7rteonLeuejhZBaJklcbJ6gwL5eWI1VTbqe',NULL),(3,'taeho@maver.com',NULL,NULL,_binary '',NULL,'taeho','{bcrypt}$2a$02ydutrj','https://user-images.githubusercontent.com/42775225/156348156-d92c9d3f-b158-4268-bac4-4c3c9660b400.jpeg'),(4,'giri@maver.com',NULL,NULL,_binary '',NULL,'giri','{bcrypt}$2a$03jytkm','https://user-images.githubusercontent.com/42775225/156348197-87907054-c438-4c7b-8337-55aaf00e3360.jpeg'),(5,'tomy@maver.com',NULL,NULL,_binary '',NULL,'tomy','{bcrypt}$2a$04vmbnym','https://user-images.githubusercontent.com/42775225/156348207-d44b8a31-4d7b-4271-b8dd-4bc74c09d825.jpeg'),(6,'james@maver.com',NULL,NULL,_binary '',NULL,'james','{bcrypt}$2a$05gngnt','https://user-images.githubusercontent.com/42775225/156348212-61b86fd0-9d1d-4a3e-b190-174b914a1171.jpeg');
+INSERT INTO `account`
+VALUES (1, 'gildong@maver.com', NULL, NULL, _binary '', NULL, 'Gildong', '{bcrypt}$2a$00asdf',
+        'https://user-images.githubusercontent.com/42775225/156348135-c44d1de2-c73f-49d9-accf-b0461f0cf740.png',
+        'local'),
+       (2, 'whynot-user@email.com', NULL, NULL, _binary '', '2022-03-09 07:08:08', 'whynot-user',
+        '{bcrypt}$2a$10$xXkjud45CmBA/rOW0B7rteonLeuejhZBaJklcbJ6gwL5eWI1VTbqe', NULL, 'local'),
+       (3, 'taeho@maver.com', NULL, NULL, _binary '', NULL, 'taeho', '{bcrypt}$2a$02ydutrj',
+        'https://user-images.githubusercontent.com/42775225/156348156-d92c9d3f-b158-4268-bac4-4c3c9660b400.jpeg',
+        'local'),
+       (4, 'giri@maver.com', NULL, NULL, _binary '', NULL, 'giri', '{bcrypt}$2a$03jytkm',
+        'https://user-images.githubusercontent.com/42775225/156348197-87907054-c438-4c7b-8337-55aaf00e3360.jpeg',
+        'local'),
+       (5, 'tomy@maver.com', NULL, NULL, _binary '', NULL, 'tomy', '{bcrypt}$2a$04vmbnym',
+        'https://user-images.githubusercontent.com/42775225/156348207-d44b8a31-4d7b-4271-b8dd-4bc74c09d825.jpeg',
+        'local'),
+       (6, 'james@maver.com', NULL, NULL, _binary '', NULL, 'james', '{bcrypt}$2a$05gngnt',
+        'https://user-images.githubusercontent.com/42775225/156348212-61b86fd0-9d1d-4a3e-b190-174b914a1171.jpeg',
+        'local');
 UNLOCK TABLES;
 
 
 
-CREATE TABLE `job` (
-  `job_id` bigint NOT NULL AUTO_INCREMENT,
-  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
-  PRIMARY KEY (`job_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `job`
+(
+    `job_id` bigint                                  NOT NULL AUTO_INCREMENT,
+    `name`   varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+    PRIMARY KEY (`job_id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 5
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 LOCK TABLES `job` WRITE;
-INSERT INTO `job` VALUES (1,'개발자'),(2,'디자이너'),(3,'기획자'),(4,'그 외');
+INSERT INTO `job`
+VALUES (1, '개발자'),
+       (2, '디자이너'),
+       (3, '기획자'),
+       (4, '그 외');
 UNLOCK TABLES;
 
 
 
-CREATE TABLE `post` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `created_dt` datetime DEFAULT NULL,
-  `updated_dt` datetime DEFAULT NULL,
-  `closed_dt` datetime DEFAULT NULL,
-  `content` varchar(2500) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `is_recruiting` bit(1) DEFAULT NULL,
-  `post_img` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `title` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `account_id` bigint DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `FKe5hjewhnd6trrdgt8i6uapkhy` (`account_id`),
-  CONSTRAINT `FKe5hjewhnd6trrdgt8i6uapkhy` FOREIGN KEY (`account_id`) REFERENCES `account` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `post`
+(
+    `id`            bigint NOT NULL AUTO_INCREMENT,
+    `created_dt`    datetime                                 DEFAULT NULL,
+    `updated_dt`    datetime                                 DEFAULT NULL,
+    `closed_dt`     datetime                                 DEFAULT NULL,
+    `content`       varchar(2500) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+    `is_recruiting` bit(1)                                   DEFAULT NULL,
+    `post_img`      varchar(255) COLLATE utf8mb4_unicode_ci  DEFAULT NULL,
+    `title`         varchar(255) COLLATE utf8mb4_unicode_ci  DEFAULT NULL,
+    `account_id`    bigint                                   DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    KEY `FKe5hjewhnd6trrdgt8i6uapkhy` (`account_id`),
+    CONSTRAINT `FKe5hjewhnd6trrdgt8i6uapkhy` FOREIGN KEY (`account_id`) REFERENCES `account` (`id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 7
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 LOCK TABLES `post` WRITE;
-INSERT INTO `post` VALUES (1,'2022-01-12 00:00:00',NULL,NULL,'공프기 팀원을 모집합니다. 저희팀은 커피를 좋아하는 사람들을 위한 서비스를 기획하고 있습니다. 개발자가 필요합니다.',_binary '','https://user-images.githubusercontent.com/42775225/156349826-a00d9152-fb83-4e90-8267-2e4bdb836f21.jpeg','[팀원모집] 공프기',1),(2,'2022-01-12 00:00:00',NULL,NULL,'캡스톤을 시작으로 창업까지 이어갈 인원을 모집합니다. 자동차를 싸고 쉽게 구매하기 위한 서비스를 기획하고 있습니다. 디자이너와 개발자를 찾고 있습니다.',_binary '','https://user-images.githubusercontent.com/42775225/156349826-a00d9152-fb83-4e90-8267-2e4bdb836f21.jpeg','캡스톤에서 창업까지',2),(3,'2022-01-12 00:00:00',NULL,NULL,'인공지능 알고리즘을 적용한 서비스를 기획하고 있습니다. 아직까지 구체적인 기획안이 없으며, 기획부터 개발 운영까지 함께할 초기 멤버를 찾고 있습니다.',_binary '','https://user-images.githubusercontent.com/42775225/156349826-a00d9152-fb83-4e90-8267-2e4bdb836f21.jpeg','인공지능 서비스 - 기획자 구함',3),(4,'2022-01-12 00:00:00',NULL,NULL,'노래를 통해 세상을 치유하고 있는 사람들을 아시나요? 그런 사람들을 위한 무료 예약 시스템을 구축하고자 합니다.',_binary '','https://user-images.githubusercontent.com/42775225/156349826-a00d9152-fb83-4e90-8267-2e4bdb836f21.jpeg','노래로 세상을 치유하는 팀',4),(5,'2022-01-12 00:00:00',NULL,NULL,'어려운 전공 과목을 함께 이겨낼 수 있도록 스터디원을 모집할 수 있는 플랫폼을 만들고자 합니다. 010-1234-5678으로 연락주세요',_binary '','https://user-images.githubusercontent.com/42775225/156349826-a00d9152-fb83-4e90-8267-2e4bdb836f21.jpeg','[팀원모집] 개발자 급구 - 스터디 서비스',5),(6,'2022-01-12 00:00:00',NULL,NULL,'과거 역사를 알아야 앞으로 같은 실수를 반복하지 않습니다. 저희는 역사를 좋아하는 사람들이 부담없이 만날 수 있는 서비스를 기획하고 있습니다.',_binary '','https://user-images.githubusercontent.com/42775225/156349826-a00d9152-fb83-4e90-8267-2e4bdb836f21.jpeg','History Maker 초기멤버',6);
+INSERT INTO `post`
+VALUES (1, '2022-01-12 00:00:00', NULL, NULL, '공프기 팀원을 모집합니다. 저희팀은 커피를 좋아하는 사람들을 위한 서비스를 기획하고 있습니다. 개발자가 필요합니다.',
+        _binary '',
+        'https://user-images.githubusercontent.com/42775225/156349826-a00d9152-fb83-4e90-8267-2e4bdb836f21.jpeg',
+        '[팀원모집] 공프기', 1),
+       (2, '2022-01-12 00:00:00', NULL, NULL,
+        '캡스톤을 시작으로 창업까지 이어갈 인원을 모집합니다. 자동차를 싸고 쉽게 구매하기 위한 서비스를 기획하고 있습니다. 디자이너와 개발자를 찾고 있습니다.', _binary '',
+        'https://user-images.githubusercontent.com/42775225/156349826-a00d9152-fb83-4e90-8267-2e4bdb836f21.jpeg',
+        '캡스톤에서 창업까지', 2),
+       (3, '2022-01-12 00:00:00', NULL, NULL,
+        '인공지능 알고리즘을 적용한 서비스를 기획하고 있습니다. 아직까지 구체적인 기획안이 없으며, 기획부터 개발 운영까지 함께할 초기 멤버를 찾고 있습니다.', _binary '',
+        'https://user-images.githubusercontent.com/42775225/156349826-a00d9152-fb83-4e90-8267-2e4bdb836f21.jpeg',
+        '인공지능 서비스 - 기획자 구함', 3),
+       (4, '2022-01-12 00:00:00', NULL, NULL, '노래를 통해 세상을 치유하고 있는 사람들을 아시나요? 그런 사람들을 위한 무료 예약 시스템을 구축하고자 합니다.',
+        _binary '',
+        'https://user-images.githubusercontent.com/42775225/156349826-a00d9152-fb83-4e90-8267-2e4bdb836f21.jpeg',
+        '노래로 세상을 치유하는 팀', 4),
+       (5, '2022-01-12 00:00:00', NULL, NULL,
+        '어려운 전공 과목을 함께 이겨낼 수 있도록 스터디원을 모집할 수 있는 플랫폼을 만들고자 합니다. 010-1234-5678으로 연락주세요', _binary '',
+        'https://user-images.githubusercontent.com/42775225/156349826-a00d9152-fb83-4e90-8267-2e4bdb836f21.jpeg',
+        '[팀원모집] 개발자 급구 - 스터디 서비스', 5),
+       (6, '2022-01-12 00:00:00', NULL, NULL,
+        '과거 역사를 알아야 앞으로 같은 실수를 반복하지 않습니다. 저희는 역사를 좋아하는 사람들이 부담없이 만날 수 있는 서비스를 기획하고 있습니다.', _binary '',
+        'https://user-images.githubusercontent.com/42775225/156349826-a00d9152-fb83-4e90-8267-2e4bdb836f21.jpeg',
+        'History Maker 초기멤버', 6);
 UNLOCK TABLES;
 
 
 
-CREATE TABLE `job_post` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `job_id` bigint DEFAULT NULL,
-  `post_id` bigint DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `constJobPost` (`job_id`,`post_id`),
-  KEY `FKtnk3psdsu3qagjy3eaitcsqqh` (`post_id`),
-  CONSTRAINT `FK28ivhoqnbkno4yjdoxqr9erx1` FOREIGN KEY (`job_id`) REFERENCES `job` (`job_id`),
-  CONSTRAINT `FKtnk3psdsu3qagjy3eaitcsqqh` FOREIGN KEY (`post_id`) REFERENCES `post` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `job_post`
+(
+    `id`      bigint NOT NULL AUTO_INCREMENT,
+    `job_id`  bigint DEFAULT NULL,
+    `post_id` bigint DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `constJobPost` (`job_id`, `post_id`),
+    KEY `FKtnk3psdsu3qagjy3eaitcsqqh` (`post_id`),
+    CONSTRAINT `FK28ivhoqnbkno4yjdoxqr9erx1` FOREIGN KEY (`job_id`) REFERENCES `job` (`job_id`),
+    CONSTRAINT `FKtnk3psdsu3qagjy3eaitcsqqh` FOREIGN KEY (`post_id`) REFERENCES `post` (`id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 14
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 LOCK TABLES `job_post` WRITE;
-INSERT INTO `job_post` VALUES (1,1,1),(2,1,2),(4,1,3),(11,1,6),(3,2,2),(5,2,3),(8,2,4),(9,2,5),(12,2,6),(6,3,3),(10,3,5),(13,3,6),(7,4,3);
+INSERT INTO `job_post`
+VALUES (1, 1, 1),
+       (2, 1, 2),
+       (4, 1, 3),
+       (11, 1, 6),
+       (3, 2, 2),
+       (5, 2, 3),
+       (8, 2, 4),
+       (9, 2, 5),
+       (12, 2, 6),
+       (6, 3, 3),
+       (10, 3, 5),
+       (13, 3, 6),
+       (7, 4, 3);
 UNLOCK TABLES;
 
 
 
-CREATE TABLE `post_apply` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `account_id` bigint DEFAULT NULL,
-  `job_id` bigint DEFAULT NULL,
-  `post_id` bigint DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `constPostApply` (`post_id`,`account_id`,`job_id`),
-  KEY `FKj0eyusby5pii3a5b9n4hud0ee` (`account_id`),
-  KEY `FKpw6ekp82yubwt4ywaq3s5mu1l` (`job_id`),
-  CONSTRAINT `FKd9vripurv4a148fn39u2yemq2` FOREIGN KEY (`post_id`) REFERENCES `post` (`id`),
-  CONSTRAINT `FKj0eyusby5pii3a5b9n4hud0ee` FOREIGN KEY (`account_id`) REFERENCES `account` (`id`),
-  CONSTRAINT `FKpw6ekp82yubwt4ywaq3s5mu1l` FOREIGN KEY (`job_id`) REFERENCES `job` (`job_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `post_apply`
+(
+    `id`         bigint NOT NULL AUTO_INCREMENT,
+    `account_id` bigint DEFAULT NULL,
+    `job_id`     bigint DEFAULT NULL,
+    `post_id`    bigint DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `constPostApply` (`post_id`, `account_id`, `job_id`),
+    KEY `FKj0eyusby5pii3a5b9n4hud0ee` (`account_id`),
+    KEY `FKpw6ekp82yubwt4ywaq3s5mu1l` (`job_id`),
+    CONSTRAINT `FKd9vripurv4a148fn39u2yemq2` FOREIGN KEY (`post_id`) REFERENCES `post` (`id`),
+    CONSTRAINT `FKj0eyusby5pii3a5b9n4hud0ee` FOREIGN KEY (`account_id`) REFERENCES `account` (`id`),
+    CONSTRAINT `FKpw6ekp82yubwt4ywaq3s5mu1l` FOREIGN KEY (`job_id`) REFERENCES `job` (`job_id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 2
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 LOCK TABLES `post_apply` WRITE;
-INSERT INTO `post_apply` VALUES (1,1,1,1);
+INSERT INTO `post_apply`
+VALUES (1, 1, 1, 1);
 UNLOCK TABLES;
 
 
 
-
-CREATE TABLE `post_favorite` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `account_id` bigint DEFAULT NULL,
-  `post_id` bigint DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `constPostFavorite` (`post_id`,`account_id`),
-  KEY `FKls6bgfyknw986o1qrnaulirvp` (`account_id`),
-  CONSTRAINT `FKls6bgfyknw986o1qrnaulirvp` FOREIGN KEY (`account_id`) REFERENCES `account` (`id`),
-  CONSTRAINT `FKtnr54tuktg3welr2u950p0mqr` FOREIGN KEY (`post_id`) REFERENCES `post` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `post_favorite`
+(
+    `id`         bigint NOT NULL AUTO_INCREMENT,
+    `account_id` bigint DEFAULT NULL,
+    `post_id`    bigint DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `constPostFavorite` (`post_id`, `account_id`),
+    KEY `FKls6bgfyknw986o1qrnaulirvp` (`account_id`),
+    CONSTRAINT `FKls6bgfyknw986o1qrnaulirvp` FOREIGN KEY (`account_id`) REFERENCES `account` (`id`),
+    CONSTRAINT `FKtnr54tuktg3welr2u950p0mqr` FOREIGN KEY (`post_id`) REFERENCES `post` (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 LOCK TABLES `post_favorite` WRITE;
 UNLOCK TABLES;
 
 
 
-CREATE TABLE `comment` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
-  `created_dt` datetime DEFAULT NULL,
-  `updated_dt` datetime DEFAULT NULL,
-  `content` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `account_id` bigint DEFAULT NULL,
-  `post_id` bigint DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  KEY `FKp41h5al2ajp1q0u6ox3i68w61` (`account_id`),
-  KEY `FKde3rfu96lep00br5ov0mdieyt` (`parent_id`),
-  KEY `FKs1slvnkuemjsq2kj4h3vhx7i1` (`post_id`),
-  CONSTRAINT `FKp41h5al2ajp1q0u6ox3i68w61` FOREIGN KEY (`account_id`) REFERENCES `account` (`id`),
-  CONSTRAINT `FKs1slvnkuemjsq2kj4h3vhx7i1` FOREIGN KEY (`post_id`) REFERENCES `post` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `comment`
+(
+    `id`         bigint                                  NOT NULL AUTO_INCREMENT,
+    `created_dt` datetime DEFAULT NULL,
+    `updated_dt` datetime DEFAULT NULL,
+    `content`    varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+    `account_id` bigint   DEFAULT NULL,
+    `post_id`    bigint   DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    KEY `FKp41h5al2ajp1q0u6ox3i68w61` (`account_id`),
+    KEY `FKs1slvnkuemjsq2kj4h3vhx7i1` (`post_id`),
+    CONSTRAINT `FKp41h5al2ajp1q0u6ox3i68w61` FOREIGN KEY (`account_id`) REFERENCES `account` (`id`),
+    CONSTRAINT `FKs1slvnkuemjsq2kj4h3vhx7i1` FOREIGN KEY (`post_id`) REFERENCES `post` (`id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 6
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 LOCK TABLES `comment` WRITE;
-INSERT INTO `comment` VALUES (1,'2021-01-11 22:00:00',NULL,'혹시 디자이너도 뽑나요?',3,1,1),(2,'2021-01-11 22:01:00',NULL,'저도 궁금합니다.',4,2,1),(3,'2021-01-11 22:02:00',NULL,'현재는 기획자와 개발자만 뽑고 있습니다.',1,1,1),(4,'2021-01-11 22:03:00',NULL,'넵, 답변 감사합니다.',3,1,1),(5,'2021-01-11 22:04:00',NULL,'위에 답변 달아두었습니다~!',1,2,1);
+INSERT INTO `comment`
+VALUES (1, '2021-01-11 22:00:00', NULL, '혹시 디자이너도 뽑나요?', 3, 1),
+       (2, '2021-01-11 22:01:00', NULL, '저도 궁금합니다.', 4, 1),
+       (3, '2021-01-11 22:02:00', NULL, '현재는 기획자와 개발자만 뽑고 있습니다.', 1, 1),
+       (4, '2021-01-11 22:03:00', NULL, '넵, 답변 감사합니다.', 3, 1),
+       (5, '2021-01-11 22:04:00', NULL, '위에 답변 달아두었습니다~!', 1, 1);
 UNLOCK TABLES;

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -20,6 +20,8 @@ CREATE TABLE `account`
     `profile_img`                    varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
     `auth_type`                      varchar(255),
     PRIMARY KEY (`id`)
+    UNIQUE KEY `UK_q0uja26qgu1atulenwup9rxyr` (`email`),
+    UNIQUE KEY `UK_s2a5omeaik0sruawqpvs18qfk` (`nickname`)
 ) ENGINE = InnoDB
   AUTO_INCREMENT = 7
   DEFAULT CHARSET = utf8mb4

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -19,9 +19,7 @@ CREATE TABLE `account`
     `password`                       varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
     `profile_img`                    varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
     `auth_type`                      varchar(255),
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `UK_q0uja26qgu1atulenwup9rxyr` (`email`),
-    UNIQUE KEY `UK_s2a5omeaik0sruawqpvs18qfk` (`nickname`)
+    PRIMARY KEY (`id`)
 ) ENGINE = InnoDB
   AUTO_INCREMENT = 7
   DEFAULT CHARSET = utf8mb4


### PR DESCRIPTION
작업 내용은 다음과 같습니다.

1. Account 테이블에 auth_type 컬럼을 추가하였습니다. (+ schema.sql  변경)
     - local (기존 이메일 인증 방식)
     - google (구글 소셜 로그인)
     - naver (네이버 소셜 로그인)
     - kakao (카카오 소셜 로그인)
2. UserAccount 객체에 OAuth2User도 implements하여 추후 SpringSecurityContextHolder에 필요한 인증 객체로 사용할 예정입니다.
3. GoogleOAuth2UserInfo에서 "sub"라고 하는 키에 들어있는 값은 OAuth2에서 사용자를 식별하는 유니크한 id값의 키입니다.
     - google : sub
     - naver : response
     - kakao : id
4.  Account를 식별자였던 email이 email과 auth_type 조합으로 변경되었습니다. (같은 이메일로 여러 소셜 로그인에 사용가능하기 때문)