### PR TITLE
[BE] OAuth2 구글 로그인 구현

### DIFF
--- a/src/main/java/handong/whynot/api/v2/AccountControllerV2.java
+++ b/src/main/java/handong/whynot/api/v2/AccountControllerV2.java
@@ -43,6 +43,7 @@ public class AccountControllerV2 {
                 .email(account.getEmail())
                 .nickname(account.getNickname())
                 .profileImg(account.getProfileImg())
+                .authType(account.getAuthType())
                 .build();
     }
 }

--- a/src/main/java/handong/whynot/handler/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/handong/whynot/handler/security/CustomAccessDeniedHandler.java
@@ -1,4 +1,4 @@
-package handong.whynot.handler;
+package handong.whynot.handler.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import handong.whynot.dto.account.AccountResponseCode;

--- a/src/main/java/handong/whynot/handler/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/handong/whynot/handler/security/CustomAuthenticationEntryPoint.java
@@ -1,4 +1,4 @@
-package handong.whynot.handler;
+package handong.whynot.handler.security;
 
 import static org.apache.commons.codec.CharEncoding.UTF_8;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;

--- a/src/main/java/handong/whynot/handler/security/CustomLogoutSuccessHandler.java
+++ b/src/main/java/handong/whynot/handler/security/CustomLogoutSuccessHandler.java
@@ -1,42 +1,44 @@
-package handong.whynot.handler;
+package handong.whynot.handler.security;
 
 import static org.apache.commons.codec.CharEncoding.UTF_8;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.OK;
 
 import java.io.IOException;
 
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.http.MediaType;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import handong.whynot.dto.account.AccountResponseCode;
-import handong.whynot.dto.common.ErrorResponseDTO;
+import handong.whynot.dto.common.ResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class LoginFailureHandler implements AuthenticationFailureHandler {
+public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
 
     private final ObjectMapper objectMapper;
 
     @Override
-    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
-                                        AuthenticationException exception) {
-        ErrorResponseDTO responseMessage = ErrorResponseDTO.of(AccountResponseCode.ACCOUNT_NOT_VALID, null);
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
+                                Authentication authentication) throws IOException, ServletException {
+
+        ResponseDTO responseMessage = ResponseDTO.of(AccountResponseCode.ACCOUNT_LOGOUT_SUCCESS);
 
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(UTF_8);
 
-        response.setStatus(BAD_REQUEST.value());
+        response.setStatus(OK.value());
 
         try {
             response.getWriter().write(objectMapper.writeValueAsString(responseMessage));

--- a/src/main/java/handong/whynot/handler/security/LoginFailureHandler.java
+++ b/src/main/java/handong/whynot/handler/security/LoginFailureHandler.java
@@ -1,44 +1,42 @@
-package handong.whynot.handler;
+package handong.whynot.handler.security;
 
 import static org.apache.commons.codec.CharEncoding.UTF_8;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-import static org.springframework.http.HttpStatus.OK;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.http.MediaType;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import handong.whynot.dto.account.AccountResponseCode;
-import handong.whynot.dto.common.ResponseDTO;
+import handong.whynot.dto.common.ErrorResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
+public class LoginFailureHandler implements AuthenticationFailureHandler {
 
     private final ObjectMapper objectMapper;
 
     @Override
-    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
-                                Authentication authentication) throws IOException, ServletException {
-
-        ResponseDTO responseMessage = ResponseDTO.of(AccountResponseCode.ACCOUNT_LOGOUT_SUCCESS);
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) {
+        ErrorResponseDTO responseMessage = ErrorResponseDTO.of(AccountResponseCode.ACCOUNT_NOT_VALID, null);
 
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(UTF_8);
 
-        response.setStatus(OK.value());
+        response.setStatus(BAD_REQUEST.value());
 
         try {
             response.getWriter().write(objectMapper.writeValueAsString(responseMessage));

--- a/src/main/java/handong/whynot/handler/security/LoginSuccessHandler.java
+++ b/src/main/java/handong/whynot/handler/security/LoginSuccessHandler.java
@@ -1,4 +1,4 @@
-package handong.whynot.handler;
+package handong.whynot.handler.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import handong.whynot.dto.account.AccountResponseDTO;

--- a/src/main/java/handong/whynot/handler/security/oauth2/OAuth2FailureHandler.java
+++ b/src/main/java/handong/whynot/handler/security/oauth2/OAuth2FailureHandler.java
@@ -1,0 +1,47 @@
+package handong.whynot.handler.security.oauth2;
+
+import handong.whynot.repository.HttpCookieOAuth2AuthorizationRequestRepository;
+import handong.whynot.util.CookieUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+
+import static handong.whynot.repository.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Value("${spring.security.oauth2.redirect-uri}")
+    public String CLIENT_REDIRECT_URI;
+
+    private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
+
+        // RedirectURL 만들기
+        Optional<String> redirectUri = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+                .map(Cookie::getValue);
+        redirectUri.ifPresent(clientURL -> CLIENT_REDIRECT_URI = clientURL);
+
+        final String targetUrl = UriComponentsBuilder.fromUriString(CLIENT_REDIRECT_URI)
+                .queryParam("error", exception.getLocalizedMessage())
+                .build().toUriString();
+
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/handong/whynot/handler/security/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/handong/whynot/handler/security/oauth2/OAuth2SuccessHandler.java
@@ -1,0 +1,72 @@
+package handong.whynot.handler.security.oauth2;
+
+import handong.whynot.domain.Account;
+import handong.whynot.dto.account.TokenResponseDTO;
+import handong.whynot.dto.account.UserAccount;
+import handong.whynot.repository.HttpCookieOAuth2AuthorizationRequestRepository;
+import handong.whynot.service.SignInTokenGenerator;
+import handong.whynot.util.CookieUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+
+import static handong.whynot.repository.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    @Value("${spring.security.oauth2.redirect-uri}")
+    public String CLIENT_REDIRECT_URI;
+
+    private final SignInTokenGenerator signInTokenGenerator;
+    private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+
+        final Account account = ((UserAccount) authentication.getPrincipal()).getAccount();
+
+        // JWT 응답
+        String accessToken = signInTokenGenerator.accessToken(account.getId());
+        String refreshToken = signInTokenGenerator.refreshToken(account.getId());
+
+        final TokenResponseDTO token = TokenResponseDTO.of(account, accessToken, refreshToken);
+
+        // RedirectURL 만들기
+        Optional<String> redirectUri = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+                .map(Cookie::getValue);
+        redirectUri.ifPresent(clientURL -> CLIENT_REDIRECT_URI = clientURL);
+
+        // 응답값 생성
+        final String targetUrl = UriComponentsBuilder.fromUriString(CLIENT_REDIRECT_URI)
+                .queryParam("accessToken", token.getAccessToken())
+                .queryParam("refreshToken", token.getRefreshToken())
+                .build().toUriString();
+
+        // 응답이 이미 클라이언트에 커밋되었는지 확인
+        if (response.isCommitted()) {
+            logger.debug("Response has already been committed. Unable to redirect to " + targetUrl);
+            return;
+        }
+
+        clearAuthenticationAttributes(request, response);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+        super.clearAuthenticationAttributes(request);
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+    }
+}

--- a/src/main/java/handong/whynot/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/handong/whynot/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,51 @@
+package handong.whynot.repository;
+
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import handong.whynot.util.CookieUtils;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+    private static final int cookieExpireSeconds = 180;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+                .map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+                .orElse(null);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+            return;
+        }
+
+        CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+    }
+}

--- a/src/main/java/handong/whynot/service/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/handong/whynot/service/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,80 @@
+package handong.whynot.service.oauth2;
+
+import handong.whynot.domain.Account;
+import handong.whynot.domain.AuthType;
+import handong.whynot.dto.account.AccountResponseCode;
+import handong.whynot.dto.account.UserAccount;
+import handong.whynot.dto.account.oauth2.OAuth2UserInfo;
+import handong.whynot.exception.account.OAuth2ProcessingException;
+import handong.whynot.repository.AccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final AccountRepository accountRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        try {
+            return processOAuth2User(userRequest, oAuth2User);
+        } catch (Exception ex) {
+            throw new InternalAuthenticationServiceException(ex.getMessage(), ex.getCause());
+        }
+    }
+
+    private OAuth2User processOAuth2User(OAuth2UserRequest oAuth2UserRequest, OAuth2User oAuth2User) {
+        String registrationId = oAuth2UserRequest.getClientRegistration().getRegistrationId();
+        if (! AuthType.isValidRegistrationId(registrationId)) {
+            throw new OAuth2ProcessingException(AccountResponseCode.ACCOUNT_OAUTH2_INVALID_REGISTRATION);
+        }
+
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(registrationId, oAuth2User.getAttributes());
+        if(StringUtils.isEmpty(oAuth2UserInfo.getEmail())) {
+            throw new OAuth2ProcessingException(AccountResponseCode.ACCOUNT_OAUTH2_PROCESS_FAILED);
+        }
+
+        Account findAccount = accountRepository.findByEmail(oAuth2UserInfo.getEmail());
+        Account account;
+
+        if (findAccount != null) {
+            account = updateExistingUser(findAccount, oAuth2UserInfo);
+        } else {
+            account = registerNewUser(oAuth2UserRequest, oAuth2UserInfo);
+        }
+
+        return UserAccount.create(account, oAuth2User.getAttributes());
+    }
+
+    private Account registerNewUser(OAuth2UserRequest oAuth2UserRequest, OAuth2UserInfo oAuth2UserInfo) {
+        System.out.println(LocalDateTime.now());
+        Account account = Account.builder()
+                            .nickname(oAuth2UserInfo.getName())
+                            .email(oAuth2UserInfo.getEmail())
+                            .profileImg(oAuth2UserInfo.getImageUrl())
+                            .authType(AuthType.valueOf(oAuth2UserRequest.getClientRegistration().getRegistrationId()))
+                            .emailVerified(true)
+                            .joinedAt(LocalDateTime.now())
+                            .build();
+
+        return accountRepository.save(account);
+    }
+
+    private Account updateExistingUser(Account existingUser, OAuth2UserInfo oAuth2UserInfo) {
+        existingUser.setNickname(oAuth2UserInfo.getName());
+        existingUser.setProfileImg(oAuth2UserInfo.getImageUrl());
+        return accountRepository.save(existingUser);
+    }
+}

--- a/src/main/java/handong/whynot/service/oauth2/OAuth2UserInfoFactory.java
+++ b/src/main/java/handong/whynot/service/oauth2/OAuth2UserInfoFactory.java
@@ -1,0 +1,20 @@
+package handong.whynot.service.oauth2;
+
+import handong.whynot.domain.AuthType;
+import handong.whynot.dto.account.AccountResponseCode;
+import handong.whynot.dto.account.oauth2.*;
+import handong.whynot.exception.account.OAuth2ProcessingException;
+
+import java.util.Map;
+
+public class OAuth2UserInfoFactory {
+
+    public static OAuth2UserInfo getOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
+        if(registrationId.equalsIgnoreCase(AuthType.google.toString())) {
+            return new GoogleOAuth2UserInfo(attributes);
+        }
+        else {
+            throw new OAuth2ProcessingException(AccountResponseCode.ACCOUNT_OAUTH2_PROCESS_FAILED);
+        }
+    }
+}

--- a/src/main/java/handong/whynot/util/CookieUtils.java
+++ b/src/main/java/handong/whynot/util/CookieUtils.java
@@ -1,0 +1,57 @@
+package handong.whynot.util;
+
+import org.springframework.util.SerializationUtils;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Base64;
+import java.util.Optional;
+
+public class CookieUtils {
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie: cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize(object));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(
+                Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+}

--- a/src/test/java/handong/whynot/api/v2/AccountControllerV2Test.java
+++ b/src/test/java/handong/whynot/api/v2/AccountControllerV2Test.java
@@ -6,7 +6,7 @@ import handong.whynot.config.SecurityConfig;
 import handong.whynot.dto.account.AccountResponseDTO;
 import handong.whynot.dto.account.SignInRequestDTO;
 import handong.whynot.dto.account.TokenResponseDTO;
-import handong.whynot.handler.CustomAuthenticationEntryPoint;
+import handong.whynot.handler.security.CustomAuthenticationEntryPoint;
 import handong.whynot.repository.AccountRepository;
 import handong.whynot.service.AccountService;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
https://github.com/callicoder/spring-boot-react-oauth2-social-login-demo
를 참고하여 구현하였습니다.

< 서비스 로직 >
1. SecurityConfig의 OAuth 설정으로 인하여
OAuth2LoginAuthenticationFilter 가 filter chain에 등록이 되고
ClientRegistrationRepository(우리 앱이 쓰는 client key, secret key 등의 정보),
OAuth2AuthorizedClientRepository(다른 웹 요청이 와도 동일한 OAuth2 사용자 유지) 이 세팅 됩니다.

2. {serverURL}/auth/login/google?redirect_uri={frontURL}로 OAuth2 로그인 요청을 받게 되면,
clientID, redirectURL 등이 담긴 OAuth2AuthorizationRequest 를 바이트로 변환하여 인코딩 합니다.
그 값을 쿠키에 담아서 클라이언트로 전달합니다.

3. 사용자가 자신의 ID, PW를 입력하여 로그인을 시도하면
OAuth2LoginAuthenticationFilter 의 attemptAuthentication 메서드를 통해서 로그인 처리를 합니다.
로그인에 성공을 했다면 OAuth2 제공자(구글)로 부터 state, code, scope 등을 전달받습니다.
그 뒤에 아까 클라이언트에 저장해두었던 OAuth2AuthorizationRequest 값을 HttpServletRequest의 쿠키에서 꺼내옵니다.
null이 아니라면 받아온 state, code를 기반으로 직렬화를 거쳐 최종적으로 Authentication 객체를 반환하게 됩니다.
(이 부분의 정확한 처리를 확인하고자 하신다면 OAuth2LoginAuthenticationFilter를 참고해주세요)

4. 그렇게 로그인에 성공하면 OAuth2SuccessHandler 로 이동하게 되고,
redirect_uri 를 넘겨 받았다면 그쪽으로
redirect_uri 를 넘겨 받지 않았다면 server에서 지정한 URL로 리다이렉트 시킵니다.

<br />
<hr />
- Request : http://localhost:9000/auth/login/google?redirect_uri=http://localhost:3000 로 테스트 하시면 됩니닷~!

<br />