### PR TITLE
[BE] 통합 검색 기능 추가

### DIFF
--- a/src/main/java/handong/whynot/api/v2/PostControllerV2.java
+++ b/src/main/java/handong/whynot/api/v2/PostControllerV2.java
@@ -171,4 +171,11 @@ public class PostControllerV2 {
 
         return ResponseDTO.of(PostResponseCode.POST_END_RECRUIT_OK);
     }
+
+    @Operation(summary = "공고 통합 검색")
+    @GetMapping("/search")
+    public List<PostResponseDTO> changeRecruiting(@RequestParam(value = "keyword") String keyword) {
+
+        return postService.searchPosts(keyword);
+    }
 }

--- a/src/main/java/handong/whynot/config/TomcatWebCustomConfig.java
+++ b/src/main/java/handong/whynot/config/TomcatWebCustomConfig.java
@@ -1,0 +1,15 @@
+package handong.whynot.config;
+
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TomcatWebCustomConfig implements WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
+
+    @Override
+    public void customize(TomcatServletWebServerFactory factory) {
+        factory.addConnectorCustomizers(
+                connector -> connector.setProperty("relaxedQueryChars", "<>[\\]^`{|}"));
+    }
+}

--- a/src/main/java/handong/whynot/repository/PostQueryRepository.java
+++ b/src/main/java/handong/whynot/repository/PostQueryRepository.java
@@ -148,4 +148,12 @@ public class PostQueryRepository {
                 )
                 .fetch();
     }
+
+    public List<Post> searchPosts(String keyword) {
+
+        return queryFactory.selectFrom(qPost)
+                .where(qPost.title.contains(keyword)
+                        .or(qPost.content.contains(keyword)))
+                .fetch();
+    }
 }

--- a/src/main/java/handong/whynot/service/PostService.java
+++ b/src/main/java/handong/whynot/service/PostService.java
@@ -375,4 +375,11 @@ public class PostService {
                 .map(PostResponseDTO::of)
                 .collect(Collectors.toList());
     }
+
+    public List<PostResponseDTO> searchPosts(String keyword) {
+
+        return postQueryRepository.searchPosts(keyword).stream()
+                .map(PostResponseDTO::of)
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
현재 검색 기능은 통합검색으로 글 제목과 내용에서 like문으로 찾는 기능으로 구현하였습니다.
추후 Post가 가진 여러 attribute 에 대해 각각의 검색이 필요하다면 `JpaSpecificationExecutor` 를 고려해도 좋을것 같습니다.

참고 branch : [feature/search](https://github.com/whynot-here/whynot-here-api-server/commit/25a2e2ce582e33697cb55eda533b8bfd45bf43ae)