### PR TITLE
[BE] Redis cache 삭제 전략 수정

### DIFF
--- a/src/main/java/handong/whynot/api/v2/PostControllerV2.java
+++ b/src/main/java/handong/whynot/api/v2/PostControllerV2.java
@@ -1,6 +1,7 @@
 package handong.whynot.api.v2;
 
 import handong.whynot.domain.Account;
+import handong.whynot.domain.Post;
 import handong.whynot.dto.common.ResponseDTO;
 import handong.whynot.dto.post.*;
 import handong.whynot.service.AccountService;
@@ -44,15 +45,20 @@ public class PostControllerV2 {
     }
 
     @Operation(summary = "공고 생성")
-    @CacheEvict(value="MainPosts", key="'MainPosts'")
+    @Caching(
+            evict = {
+                    @CacheEvict(value="MainPosts", key="'MainPosts'"),
+                    @CacheEvict(value="CategoryPosts", allEntries = true)
+            }
+    )
     @PostMapping("")
     @ResponseStatus(CREATED)
-    public ResponseDTO createPost(@RequestBody PostRequestDTO request) {
+    public PostResponseDTO createPost(@RequestBody PostRequestDTO request) {
 
         Account account = accountService.getCurrentAccount();
-        postService.createPost(request, account);
+        PostResponseDTO createdPost = PostResponseDTO.of(postService.createPost(request, account));
 
-        return ResponseDTO.of(PostResponseCode.POST_CREATE_OK);
+        return createdPost;
     }
 
     @Operation(summary = "공고 단건 조회")

--- a/src/main/java/handong/whynot/service/PostService.java
+++ b/src/main/java/handong/whynot/service/PostService.java
@@ -16,6 +16,7 @@ import handong.whynot.util.CookieUtils;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletRequest;
@@ -135,6 +136,7 @@ public class PostService {
                 .recruitTotalCnt(request.getRecruitTotalCnt())
                 .recruitCurrentCnt(request.getRecruitCurrentCnt())
                 .communicationTool(request.getCommunicationTool())
+                .views(0)
                 .isRecruiting(true)
                 .build();
 
@@ -161,7 +163,13 @@ public class PostService {
     }
 
     @Transactional
-    @CacheEvict(value="Post", key="'Post#' + #id")
+    @Caching(
+            evict = {
+                    @CacheEvict(value="Post", key="'Post#' + #id"),
+                    @CacheEvict(value="MainPosts", key="'MainPosts'"),
+                    @CacheEvict(value="CategoryPosts", allEntries = true)
+            }
+    )
     public PostResponseDTO getPost(HttpServletRequest request, HttpServletResponse response, Long id) {
 
         // 존재하는 post 인지 확인

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -118,8 +118,8 @@ cloud:
 jwt:
   secretKey: ${jwt.token.secret}
   expiredTime:
-    access-token: 300
-    refresh-token: 3000
+    access-token: 10000
+    refresh-token: 20000
 
 springdoc:
   api-docs:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -101,8 +101,8 @@ cloud:
 jwt:
   secretKey: ${jwt.token.secret}
   expiredTime:
-    access-token: 300
-    refresh-token: 3000
+    access-token: 10000
+    refresh-token: 20000
 
 springdoc:
   api-docs:


### PR DESCRIPTION
1. **공고 생성** 했을 때, **카테고리를 기반으로 공고를 조회**(`/v2/posts/category/{id}`) 하는 캐시 데이터도 
날려주어야 하는데 빠져있어서 추가하였습니다.

2. 조회수가 반영되지 않는다는 말을 듣고, 공고 단건 조회 시 cache 삭제 조건도 추가하였는데요.
(이 조건은 추후 사용자가 많아지면 캐시 유지 시간을 줄이고, 캐싱 삭제 조건은 제거해야할 수 있습니다.)

3. 토큰 시간을 조정했습니다. (access: 약 1주, refresh: 약 2주)