### PR TITLE
[BE] 공고 수정 API 버그 수정

### DIFF
--- a/src/main/java/handong/whynot/domain/Post.java
+++ b/src/main/java/handong/whynot/domain/Post.java
@@ -25,10 +25,6 @@ public class Post extends BaseTimeEntity {
     @Column(name = "id")
     private Long id;
 
-    @Builder.Default
-    @OneToMany(mappedBy = "post")
-    private List<JobPost> jobPosts = new ArrayList<>();
-
     @ManyToOne
     @JoinColumn(name = "account_id")
     private Account createdBy;
@@ -42,9 +38,6 @@ public class Post extends BaseTimeEntity {
 
     @Column(name = "content")
     private String content;
-
-    @Column(name = "post_img")
-    private String postImg;
 
     @Column(name = "is_recruiting")
     private boolean isRecruiting;
@@ -76,11 +69,10 @@ public class Post extends BaseTimeEntity {
     private List<PostImageLink> links = new ArrayList<>();
 
     @Builder
-    public Post(Account createdBy, String title, String content, String postImg) {
+    public Post(Account createdBy, String title, String content) {
         this.createdBy = createdBy;
         this.title = title;
         this.content = content;
-        this.postImg = postImg;
         isRecruiting = true;
     }
 
@@ -88,9 +80,18 @@ public class Post extends BaseTimeEntity {
         this.links = links;
     }
 
-    public void update(PostRequestDTO request) {
+    public void update(PostRequestDTO request, Category category, List<PostImageLink> imageLinks) {
         title = request.getTitle();
         content = request.getContent();
+        categoryId = category;
+        closedDt = request.getClosedDt();
+        ownerContactType = request.getOwnerContact().getType();
+        ownerContactValue = request.getOwnerContact().getValue();
+        recruitTotalCnt = request.getRecruitTotalCnt();
+        recruitCurrentCnt = request.getRecruitCurrentCnt();
+        communicationTool = request.getCommunicationTool();
+        links.clear();
+        links.addAll(imageLinks);
     }
 
     public void increaseViews() {

--- a/src/main/java/handong/whynot/service/PostService.java
+++ b/src/main/java/handong/whynot/service/PostService.java
@@ -235,15 +235,24 @@ public class PostService {
 
     }
 
+    @Transactional
     public void updatePost(Long postId, PostRequestDTO request, Account account) {
 
+        // 존재하는 post인지 확인
         Post post = postRepository.findByIdAndCreatedBy(postId, account)
                 .orElseThrow(() -> new PostNotFoundException(PostResponseCode.POST_READ_FAIL));
 
-        post.update(request);
+        // 존재하는 카테고리인지 확인
+        Category category = categoryRepository.findById(request.getCategoryId())
+                .orElseThrow(() -> new CategoryNotFoundException(CategoryResponseCode.CATEGORY_READ_FAIL));
 
-        postRepository.save(post);
+        // 이미지 정보 만들기
+        List<PostImageLink> links = request.getImageLinks().stream()
+                .map(link -> PostImageLink.of(link, post))
+                .collect(Collectors.toList());
 
+        // 정보 업데이트
+        post.update(request, category, links);
     }
 
 


### PR DESCRIPTION
공고 수정 API에서 title, content 만 수정되는 버그가 있었습니다.
버그 수정과 동시에 더 이상 사용하지 않는 컬럼 정보(jobPosts, postImg)를 삭제하였습니다.