### PR TITLE
[BE] 공고 조회 시 createdDt 내림차순 정렬

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,10 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.mockito:mockito-inline'
+}
 
+clean {
+    delete file('src/main/generated')
 }
 
 sourceSets {

--- a/src/main/java/handong/whynot/api/v2/PostControllerV2.java
+++ b/src/main/java/handong/whynot/api/v2/PostControllerV2.java
@@ -161,7 +161,7 @@ public class PostControllerV2 {
         return ResponseDTO.of(PostResponseCode.POST_DELETE_APPLY_OK);
     }
 
-    @Operation(summary = "생성한 공고 전체 조회성")
+    @Operation(summary = "생성한 공고 전체 조회")
     @GetMapping("/own")
     public List<PostResponseDTO> getMyPosts() {
 

--- a/src/main/java/handong/whynot/repository/PostQueryRepository.java
+++ b/src/main/java/handong/whynot/repository/PostQueryRepository.java
@@ -67,6 +67,9 @@ public class PostQueryRepository {
                         select(qPostFavorite.post.id).from(qPostFavorite)
                                 .where(qPostFavorite.account.id.eq(accountId))
                 ))
+                .orderBy(
+                        qPost.createdDt.desc()
+                )
                 .fetch();
     }
 
@@ -93,6 +96,9 @@ public class PostQueryRepository {
                         select(qPostApply.post.id).from(qPostApply)
                                 .where(qPostApply.account.id.eq(accountId))
                 ))
+                .orderBy(
+                        qPost.createdDt.desc()
+                )
                 .fetch();
     }
 
@@ -154,6 +160,9 @@ public class PostQueryRepository {
         return queryFactory.selectFrom(qPost)
                 .where(qPost.title.contains(keyword)
                         .or(qPost.content.contains(keyword)))
+                .orderBy(
+                        qPost.createdDt.desc()
+                )
                 .fetch();
     }
 }

--- a/src/main/java/handong/whynot/service/PostService.java
+++ b/src/main/java/handong/whynot/service/PostService.java
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -379,6 +380,7 @@ public class PostService {
 
         return posts.stream()
                 .map(PostResponseDTO::of)
+                .sorted(Comparator.comparing(PostResponseDTO::getCreatedDt, Comparator.reverseOrder()))
                 .collect(Collectors.toList());
     }
 
@@ -420,6 +422,7 @@ public class PostService {
             for (Category it : childrenCategoryList) {
                 responseDTOList.addAll(postRepository.findAllByCategoryId(it).stream()
                         .map(PostResponseDTO::of)
+                        .sorted(Comparator.comparing(PostResponseDTO::getCreatedDt, Comparator.reverseOrder()))
                         .collect(Collectors.toList()));
             }
             return responseDTOList.stream().distinct().collect(Collectors.toList());
@@ -427,6 +430,7 @@ public class PostService {
 
         return postRepository.findAllByCategoryId(category).stream()
                 .map(PostResponseDTO::of)
+                .sorted(Comparator.comparing(PostResponseDTO::getCreatedDt, Comparator.reverseOrder()))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
1. 아래의 경우, 공고(post) 조회 시 createdDt 기준으로 내림차순 되도록 수정하였습니다.

- `/v2/post/own` : 본인이 생성한 공고 전체 조회
- `/v2/post/category/{id}` : 카테고리 id 기반 공고 전체 조회
- `/v2/post/favorite` : ‘좋아요’ 공고 전체 조회
- `/v2/post/apply` : 신청한 공고 전체 조회
- `/v2/post/search` : 공고 통합 검색

2. 추가적으로, 빌드 시 Q파일 때문에 에러 나는 경우도 함께 보완하였습니다.