### PR TITLE
[BE] 이미지 최대 용량 조절 (3MB -> 10MB)

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -100,8 +100,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 3MB
-      max-request-size: 3MB
+      max-file-size: 10MB
+      max-request-size: 10MB
 
 cloud:
   aws:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -83,8 +83,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 3MB
-      max-request-size: 3MB
+      max-file-size: 10MB
+      max-request-size: 10MB
 
 cloud:
   aws:


### PR DESCRIPTION
생각보다 `Error: Network error` 로 공고를 올리지 못했다는 피드백이 많아서 
해당 이슈 원인인 이미지 최대 용량을 조절하려고 합니다.

- before: 3MB
- after : 10MB