### PR TITLE
[BE] 공고 등록, 수정 시 기입 정보 변경

### DIFF
--- a/src/main/java/handong/whynot/domain/Post.java
+++ b/src/main/java/handong/whynot/domain/Post.java
@@ -85,11 +85,6 @@ public class Post extends BaseTimeEntity {
         content = request.getContent();
         categoryId = category;
         closedDt = request.getClosedDt();
-        ownerContactType = request.getOwnerContact().getType();
-        ownerContactValue = request.getOwnerContact().getValue();
-        recruitTotalCnt = request.getRecruitTotalCnt();
-        recruitCurrentCnt = request.getRecruitCurrentCnt();
-        communicationTool = request.getCommunicationTool();
         links.clear();
         links.addAll(imageLinks);
     }

--- a/src/main/java/handong/whynot/service/PostService.java
+++ b/src/main/java/handong/whynot/service/PostService.java
@@ -132,11 +132,6 @@ public class PostService {
                 .content(request.getContent())
                 .categoryId(category)
                 .closedDt(request.getClosedDt())
-                .ownerContactType(request.getOwnerContact().getType())
-                .ownerContactValue(request.getOwnerContact().getValue())
-                .recruitTotalCnt(request.getRecruitTotalCnt())
-                .recruitCurrentCnt(request.getRecruitCurrentCnt())
-                .communicationTool(request.getCommunicationTool())
                 .views(0)
                 .isRecruiting(true)
                 .build();


### PR DESCRIPTION
공고 등록, 수정 페이지가 아래 그림으로 변경됩니다.
등록, 수정 시 최소한의 정보만으로 간편하게 등록할 수 있도록 변경합니다.

![image](https://user-images.githubusercontent.com/42775225/208674178-eeb5bb84-9a91-4f1c-a856-c1f02518b504.png)

- title : 제목
- content : 내용
- imageLinks : 이미지 링크
- categoryId : 카테고리
- closedDt : 마감일 (필수 아님)

그 외의 정보는 request로 넘기더라도 반영되지 않습니다.


