### PR TITLE
[BE] 학생 인증 단계에 따른 Role 정책 추가

### DIFF
--- a/src/main/java/handong/whynot/config/SecurityConfig.java
+++ b/src/main/java/handong/whynot/config/SecurityConfig.java
@@ -108,6 +108,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         configuration.addAllowedOrigin("http://localhost:3000");
         configuration.addAllowedOrigin("http://localhost:9000");
         configuration.addAllowedOrigin("https://why-not-here.netlify.app");
+        configuration.addAllowedOrigin("https://why-not-here.o-r.kr");
+        configuration.addAllowedOrigin("http://127.0.0.1:5173");
 
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");

--- a/src/main/java/handong/whynot/config/WebConfig.java
+++ b/src/main/java/handong/whynot/config/WebConfig.java
@@ -13,7 +13,9 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOrigins(
                         "http://localhost:3000",
                         "http://localhost:9000",
-                        "https://why-not-here.netlify.app"
+                        "https://why-not-here.netlify.app",
+                        "https://why-not-here.o-r.kr",
+                        "http://127.0.0.1:5173"
                 )
                 .allowCredentials(true)
                 .allowedMethods("*")

--- a/src/main/java/handong/whynot/domain/AccountRole.java
+++ b/src/main/java/handong/whynot/domain/AccountRole.java
@@ -1,0 +1,32 @@
+package handong.whynot.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class AccountRole {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id")
+    private Account account;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_id")
+    private Role role;
+
+    @Builder
+    public AccountRole(Account account, Role role) {
+        this.account = account;
+        this.role = role;
+    }
+}

--- a/src/main/java/handong/whynot/domain/Role.java
+++ b/src/main/java/handong/whynot/domain/Role.java
@@ -1,0 +1,28 @@
+package handong.whynot.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name="code")
+    private String code;
+
+    @Column(name="name")
+    private String name;
+
+    @OneToMany(mappedBy = "role", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<AccountRole> accountRoles = new ArrayList<>();
+}

--- a/src/main/java/handong/whynot/dto/account/AccountResponseCode.java
+++ b/src/main/java/handong/whynot/dto/account/AccountResponseCode.java
@@ -8,34 +8,33 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AccountResponseCode implements ResponseCode {
     ACCOUNT_CREATE_OK(20001, "사용자 [생성]에 성공하였습니다."),
-    ACCOUNT_CREATE_FAIL_ALREADY_EXIST(40001, "사용자 [생성]에 실패하였습니다. - 이미 존재함"),
-
     ACCOUNT_READ_OK(20002, "사용자 [조회]에 성공하였습니다."),
-    ACCOUNT_READ_FAIL(40002, "사용자 [조회]에 실패하였습니다."),
-
     ACCOUNT_UPDATE_OK(20003, "사용자 [수정]에 성공하였습니다."),
-    ACCOUNT_UPDATE_FAIL_NOT_FOUND(40003, "사용자 [수정]에 실패하였습니다. - 해당 id 찾을 수 없음"),
-
     ACCOUNT_DELETE_OK(20004, "사용자 [삭제]에 성공하였습니다."),
-    ACCOUNT_DELETE_FAIL_NOT_FOUND(40004, "사용자 [삭제]에 실패하였습니다. - 해당 id 찾을 수 없음"),
+    ACCOUNT_CREATE_TOKEN_OK(20005, "사용자 [토큰생성]에 성공하였습니다."),
+    ACCOUNT_VERIFY_OK(20006, "사용자 [이메일 토큰검증]에 성공하였습니다."),
+    ACCOUNT_VALID_DUPLICATE(20007, "사용 가능한 인자입니다."),
+    ACCOUNT_LOGOUT_SUCCESS(20008, "로그아웃 성공하였습니다."),
 
+    ACCOUNT_CREATE_FAIL_ALREADY_EXIST(40001, "사용자 [생성]에 실패하였습니다. - 이미 존재함"),
+    ACCOUNT_READ_FAIL(40002, "사용자 [조회]에 실패하였습니다."),
+    ACCOUNT_UPDATE_FAIL_NOT_FOUND(40003, "사용자 [수정]에 실패하였습니다. - 해당 id 찾을 수 없음"),
+    ACCOUNT_DELETE_FAIL_NOT_FOUND(40004, "사용자 [삭제]에 실패하였습니다. - 해당 id 찾을 수 없음"),
     ACCOUNT_NOT_VALID_FROM(40005, "사용자 [입력검증]에 실패하였습니다."),
     ACCOUNT_ALREADY_EXIST_EMAIL(40006, "사용자 [중복검증]에 실패하였습니다. - 이미 사용중인 이메일입니다."),
     ACCOUNT_ALREADY_EXIST_NICKNAME(40007, "사용자 [중복검증]에 실패하였습니다. - 이미 사용중인 닉네임입니다."),
     ACCOUNT_NOT_VALID_TOKEN(40008, "사용자 [이메일 토큰검증]에 실패하였습니다."),
-    ACCOUNT_CREATE_TOKEN_OK(20005, "사용자 [토큰생성]에 성공하였습니다."),
-    ACCOUNT_VERIFY_OK(20006, "사용자 [이메일 토큰검증]에 성공하였습니다."),
     ACCOUNT_FORBIDDEN(40009, "사용자 인증이 필요합니다."),
     ACCOUNT_NOT_VALID(40010, "사용자 아이디 혹은 비밀번호가 일치하지 않습니다."),
-
-    ACCOUNT_VALID_DUPLICATE(20007, "사용 가능한 인자입니다."),
-    ACCOUNT_LOGOUT_SUCCESS(20008, "로그아웃 성공하였습니다."),
     ACCOUNT_TOKEN_EXPIRED(40011, "만료된 토큰입니다."),
     ACCOUNT_NOT_VALID_TOKEN_SECRET(40012, "올바르지 않은 jwt 토큰 시크릿입니다."),
     ACCOUNT_OAUTH2_PROCESS_FAILED(40013, "OAuth2 처리 실패하였습니다."),
     ACCOUNT_OAUTH2_INVALID_REGISTRATION(40014, "지원하지 않는 OAuth2 서버입니다."),
     ACCOUNT_OAUTH2_NOT_PROVIDED_VALUE(40015, "필수 사용자 정보가 제공되지 않았습니다."),
-    ACCOUNT_OAUTH2_EXIST_SAME_EMAIL(40016, "동일한 이메일이 사용되고 있습니다.");
+    ACCOUNT_OAUTH2_EXIST_SAME_EMAIL(40016, "동일한 이메일이 사용되고 있습니다."),
+    ALREADY_EXIST_ROLE(40017, "이미 가지고 있는 Role 입니다."),
+    ROLE_READ_FAIL(40018, "존재하지 않는 Role 입니다.");
+
 
     private final Integer statusCode;
     private final String message;

--- a/src/main/java/handong/whynot/dto/account/UserAccount.java
+++ b/src/main/java/handong/whynot/dto/account/UserAccount.java
@@ -3,7 +3,6 @@ package handong.whynot.dto.account;
 import handong.whynot.domain.Account;
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
@@ -19,12 +18,12 @@ public class UserAccount extends User implements OAuth2User {
     private Map<String, Object> attributes;
 
     public UserAccount(Account account) {
-        super(account.getNickname(), account.getPassword() == null ? "" : account.getPassword(), List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        super(account.getNickname(), account.getPassword() == null ? "" : account.getPassword(), account.getAuthorityList());
         this.account = account;
     }
 
     public UserAccount(String accountId) {
-        super(accountId, "", List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        super(accountId, "", List.of());
         this.accountId = accountId;
     }
 

--- a/src/main/java/handong/whynot/exception/account/AccountAlreadyExistRoleException.java
+++ b/src/main/java/handong/whynot/exception/account/AccountAlreadyExistRoleException.java
@@ -1,0 +1,11 @@
+package handong.whynot.exception.account;
+
+import handong.whynot.dto.common.ResponseCode;
+import handong.whynot.exception.AbstractBaseException;
+
+public class AccountAlreadyExistRoleException extends AbstractBaseException {
+
+  public AccountAlreadyExistRoleException(ResponseCode responseCode) {
+    super(responseCode);
+  }
+}

--- a/src/main/java/handong/whynot/exception/account/RoleNotFoundException.java
+++ b/src/main/java/handong/whynot/exception/account/RoleNotFoundException.java
@@ -1,0 +1,11 @@
+package handong.whynot.exception.account;
+
+import handong.whynot.dto.common.ResponseCode;
+import handong.whynot.exception.AbstractBaseException;
+
+public class RoleNotFoundException extends AbstractBaseException {
+
+  public RoleNotFoundException(ResponseCode responseCode) {
+    super(responseCode);
+  }
+}

--- a/src/main/java/handong/whynot/filter/CustomAuthorizationFilter.java
+++ b/src/main/java/handong/whynot/filter/CustomAuthorizationFilter.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -55,7 +56,8 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
                 String accountId = jwtClaimsSet.getSubject();
                 UserAccount userAccount = new UserAccount(accountId);
                 UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
-                        new UsernamePasswordAuthenticationToken(userAccount, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+                        new UsernamePasswordAuthenticationToken(userAccount, null,
+                          jwtClaimsSet.getStringListClaim("roles").stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList()));
 
                 SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
             }

--- a/src/main/java/handong/whynot/handler/security/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/handong/whynot/handler/security/oauth2/OAuth2SuccessHandler.java
@@ -17,6 +17,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.transaction.Transactional;
 import java.io.IOException;
 import java.util.Optional;
 
@@ -33,13 +34,14 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     public String CLIENT_REDIRECT_URI;
 
     @Override
+    @Transactional
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
 
         final Account account = ((UserAccount) authentication.getPrincipal()).getAccount();
 
         // JWT 응답
-        String accessToken = signInTokenGenerator.accessToken(account.getId());
-        String refreshToken = signInTokenGenerator.refreshToken(account.getId());
+        String accessToken = signInTokenGenerator.accessToken(account);
+        String refreshToken = signInTokenGenerator.refreshToken(account);
 
         final TokenResponseDTO token = TokenResponseDTO.of(account, accessToken, refreshToken);
 

--- a/src/main/java/handong/whynot/repository/RoleRepository.java
+++ b/src/main/java/handong/whynot/repository/RoleRepository.java
@@ -1,0 +1,11 @@
+package handong.whynot.repository;
+
+import handong.whynot.domain.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+
+  Optional<Role> findByCode(String code);
+}

--- a/src/main/java/handong/whynot/service/AccountService.java
+++ b/src/main/java/handong/whynot/service/AccountService.java
@@ -165,6 +165,7 @@ public class AccountService implements UserDetailsService {
         return account;
     }
 
+    @Transactional
     public TokenResponseDTO signIn(SignInRequestDTO signInRequest) {
 
         UsernamePasswordAuthenticationToken authenticationToken =
@@ -179,8 +180,8 @@ public class AccountService implements UserDetailsService {
             throw new AccountNotFoundException(AccountResponseCode.ACCOUNT_READ_FAIL);
         }
 
-        String accessToken = signInTokenGenerator.accessToken(account.getId());
-        String refreshToken = signInTokenGenerator.refreshToken(account.getId());
+        String accessToken = signInTokenGenerator.accessToken(account);
+        String refreshToken = signInTokenGenerator.refreshToken(account);
 
         return TokenResponseDTO.of(account, accessToken, refreshToken);
     }

--- a/src/main/java/handong/whynot/service/RoleService.java
+++ b/src/main/java/handong/whynot/service/RoleService.java
@@ -1,0 +1,21 @@
+package handong.whynot.service;
+
+import handong.whynot.domain.Role;
+import handong.whynot.dto.account.AccountResponseCode;
+import handong.whynot.exception.account.RoleNotFoundException;
+import handong.whynot.repository.RoleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoleService {
+
+  private final RoleRepository roleRepository;
+
+  public Role getRoleByCode(String code) {
+
+    return roleRepository.findByCode(code)
+      .orElseThrow(() -> new RoleNotFoundException(AccountResponseCode.ROLE_READ_FAIL));
+  }
+}

--- a/src/main/java/handong/whynot/service/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/handong/whynot/service/oauth2/CustomOAuth2UserService.java
@@ -2,6 +2,7 @@ package handong.whynot.service.oauth2;
 
 import handong.whynot.domain.Account;
 import handong.whynot.domain.AuthType;
+import handong.whynot.domain.Role;
 import handong.whynot.dto.account.AccountResponseCode;
 import handong.whynot.dto.account.UserAccount;
 import handong.whynot.dto.account.oauth2.OAuth2UserInfo;
@@ -11,6 +12,7 @@ import handong.whynot.exception.account.OAuth2ExistEmailException;
 import handong.whynot.exception.account.OAuth2ProcessingException;
 import handong.whynot.repository.AccountRepository;
 import handong.whynot.service.CategoryService;
+import handong.whynot.service.RoleService;
 import handong.whynot.util.NicknameMaker;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -21,6 +23,7 @@ import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 
 @Service
@@ -29,8 +32,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final AccountRepository accountRepository;
     private final CategoryService categoryService;
+    private final RoleService roleService;
 
     @Override
+    @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) {
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
@@ -86,6 +91,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 .oauthCI(oAuth2UserInfo.getId())
                 .categoryOrder(categoryService.initOrder())
                 .build();
+
+        final Role role = roleService.getRoleByCode("ROLE_GUEST");
+        account.addAccountRole(role);
 
         return accountRepository.save(account);
     }

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -365,3 +365,31 @@ CREATE TABLE `user_feedback`
     `description` varchar(2000) not null,
     PRIMARY KEY (`id`)
 );
+
+CREATE TABLE `account_role`
+(
+    `id`         bigint NOT NULL AUTO_INCREMENT,
+    `created_dt` datetime,
+    `updated_dt` datetime,
+    `role_id`    int,
+    `account_id` int,
+    PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `role`
+(
+    `id`   bigint       NOT NULL AUTO_INCREMENT,
+    `code` varchar(255) not null,
+    `name` varchar(255) not null,
+    PRIMARY KEY (`id`)
+);
+
+LOCK
+TABLES `role` WRITE;
+INSERT INTO `role` (`id`, `code`, `name`)
+VALUES (1, 'ROLE_ADMIN', '운영자'),
+       (2, 'ROLE_USER', '사용자'),
+       (3, 'ROLE_MANAGER', '외부 매니저'),
+       (4, 'ROLE_GUEST', '게스트');
+UNLOCK
+TABLES;


### PR DESCRIPTION
## 작업내역

#### 1. CORS 설정 추가
새로운 프론트 주소와 관리자 페이지 작업을 위한 로컬호스트(http://127.0.0.1:5173) 설정 추가하였습니다.

<br />

#### 2. Role 정책 추가

정책 구분은 다음과 같습니다.

<table> 	
  <tr>    
    <td>Index</td> 	    
    <td>Code</td> 
    <td>Description</td> 
  </tr>	
  <tr>	    
    <td>1</td> 	    
    <td>ROLE_ADMIN</td>	    
    <td>운영자</td> 	    
  </tr> 
  <tr>	    
    <td>2</td> 	    
    <td>ROLE_USER</td>	    
    <td>사용자</td> 	    
  </tr> 
  <tr>	    
    <td>3</td> 	    
    <td>ROLE_MANAGER</td>	    
    <td>외부 매니저</td> 	    
  </tr> 
  <tr>	    
    <td>4</td> 	    
    <td>ROLE_GUEST</td>	    
    <td>게스트</td> 	    
  </tr> 
</table>

일반 사용자는 소셜 로그인을 통해 GUEST 역할을 가지게 되고,
한동대학교 학생 인증을 완료하면 USER 역할을 가지게 됩니다.

픽키몰과 같은 외부 매니저급 권한을 MANAGER로 사용할 예정입니다.